### PR TITLE
Add test section to cabal configuration

### DIFF
--- a/QuickCheck.cabal
+++ b/QuickCheck.cabal
@@ -1,6 +1,6 @@
 Name: QuickCheck
 Version: 2.6
-Cabal-Version: >= 1.6
+Cabal-Version: >= 1.8
 Build-type: Simple
 License: BSD3
 License-file: LICENSE
@@ -98,3 +98,15 @@ library
       cpp-options: -DNO_ST_MONAD -DNO_MULTI_PARAM_TYPE_CLASSES
   Other-Modules:
     Test.QuickCheck.Exception
+
+Test-Suite test-quickcheck
+    type: exitcode-stdio-1.0
+    hs-source-dirs:
+        ., examples
+    main-is: Heap.hs
+    build-depends:
+        base
+        , QuickCheck == 2.6
+        , random
+        , template-haskell >= 2.4
+        , test-framework >= 0.4 && < 0.9


### PR DESCRIPTION
Initial test section added. To add all example/*.hs as tests, a "driver" file has to be created. I'm noting that Heap.hs has failed tests, but the failure doesn't "bubble up" to the caller ...
