### PR TITLE
Set homepage to github in QuickCheck.cabal

### DIFF
--- a/QuickCheck.cabal
+++ b/QuickCheck.cabal
@@ -10,7 +10,7 @@ Author: Koen Claessen <koen@chalmers.se>
 Maintainer: QuickCheck developers <quickcheck@projects.haskell.org>
 Bug-reports: mailto:quickcheck@projects.haskell.org
 Tested-with: GHC >=6.8, Hugs, UHC
-Homepage: http://code.haskell.org/QuickCheck
+Homepage: https://github.com/nick8325/quickcheck
 Category:       Testing
 Synopsis:       Automatic testing of Haskell programs
 Description:


### PR DESCRIPTION
Not sure if there's a reason for maintaining the old homepage link?

Old link displays file listing with a README that states:

"QuickCheck development has moved to git:
   https://github.com/nick8325/quickcheck"

Updating QuickCheck.cabal to link directly to here.
