### PR TITLE
Added flag to toggle shrinking.

### DIFF
--- a/Test/QuickCheck/Test.hs
+++ b/Test/QuickCheck/Test.hs
@@ -40,6 +40,7 @@ data Args
   , maxDiscardRatio :: Int               -- ^ Maximum number of discarded tests per successful test before giving up
   , maxSize         :: Int               -- ^ Size to use for the biggest test cases
   , chatty          :: Bool              -- ^ Whether to print anything
+  , doShrinking     :: Bool              -- ^ Whether to activate shrinking
   }
  deriving ( Show, Read )
 
@@ -91,7 +92,7 @@ stdArgs = Args
   , maxDiscardRatio = 10
   , maxSize         = 100
   , chatty          = True
--- noShrinking flag?
+  , doShrinking     = True
   }
 
 -- | Tests a property and prints the results to 'stdout'.
@@ -127,7 +128,7 @@ quickCheckWithResult a p = (if chatty a then withStdioTerminal else withNullTerm
                  , numSuccessShrinks         = 0
                  , numTryShrinks             = 0
                  , numTotTryShrinks          = 0
-                 } (unGen (unProperty (property' p)))
+                 } (unGen (unProperty (toggleShrinking (property' p))))
   where computeSize' n d
           -- e.g. with maxSuccess = 250, maxSize = 100, goes like this:
           -- 0, 1, 2, ..., 99, 0, 1, 2, ..., 99, 0, 2, 4, ..., 98.
@@ -142,6 +143,9 @@ quickCheckWithResult a p = (if chatty a then withStdioTerminal else withNullTerm
         property' p
           | exhaustive p = once (property p)
           | otherwise = property p
+        toggleShrinking p
+          | doShrinking a = p
+          | otherwise     = (noShrinking p)
 
 -- | Tests a property and prints the results and all test cases generated to 'stdout'.
 -- This is just a convenience function that means the same as @'quickCheck' . 'verbose'@.


### PR DESCRIPTION
### Description

The current QuickCheck API provides this way of disabling shrinking:

``` haskell
  quickCheck (noShrinking prop_something)
```

This patch adds a more "consistent", albeit verbose, way of disabling it in relation to other flags (e.g.: `chatty`, `maxSize`, `maxDiscardRatio`):

``` haskell
  quickCheckWith stdArgs { doShrinking = False } prop_something
```
### Discussion

Things not addressed in patch / discussion:

The `noShrinking` function still works but could be removed.

Unsure about this patch anyway -- adding only for consistency.  `noShrinking` definitely can look nicer:

``` haskell
quickCheckNS = quickCheck . noShrinking
quickCheckNS = quickCheckWith stdArgs { doShrinking = False } prop_something
```

Another option to keep consistency would be doing the reverse, making `chatty`, `maxsize`, etc. functions that operate on properties, eliminating the need for quickCheckWith and args altogether:

``` haskell
  quickCheck (chatty (maxSize 100 prop_something))

-- some custom quickcheck runners:
quickCheckCS n = quickCheck . chatty . maxSize n
quickCheck50 = quickCheck . maxSize 50
```
