### PR TITLE
Test/QuickCheck/All.hs: fix 'quickCheckAll' to read haskell sources in UTF-8

### DIFF
--- a/examples/Heap.hs
+++ b/examples/Heap.hs
@@ -146,6 +146,8 @@ instance (Ord a, Arbitrary a) => Arbitrary (Heap a) where
 -- main
 
 return []
+-- quickCheckAll reads this file and treats it as UTF-8
+-- Here is a bait to test: Привет!
 main = $(quickCheckAll)
 
 --------------------------------------------------------------------------


### PR DESCRIPTION
Today I've got an Agda build failure on a box running LANG=C locale (UTF-8
incapable).

```
examples/Heap.hs:151:10:
   Exception when trying to run compile-time code:
     examples/Heap.hs: hGetContents: invalid argument (invalid byte
```

sequence)
         Code: quickCheckAll
       In the expression: $quickCheckAll
       In an equation for `main': main = $quickCheckAll

It's a common error of a 'readFile' assuming locale input. Fixed to read in
UTF-8 in recent GHCs.

Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
