### PR TITLE
Use lookupValueName to check if name exists

### DIFF
--- a/Test/QuickCheck/All.hs
+++ b/Test/QuickCheck/All.hs
@@ -20,6 +20,7 @@ import Test.QuickCheck.Property hiding (Result)
 import Test.QuickCheck.Test
 import Data.Char
 import Data.List
+import Data.Maybe
 import Control.Monad
 
 import qualified System.IO as S
@@ -115,10 +116,10 @@ forAllProperties = do
 #endif
       quickCheckOne :: (Int, String) -> Q [Exp]
       quickCheckOne (l, x) = do
-        exists <- (warning x >> return False) `recover` (reify (mkName x) >> return True)
+        exists <- fmap isJust $ lookupValueName x
         if exists then sequence [ [| ($(stringE $ x ++ " from " ++ filename ++ ":" ++ show l),
                                      property $(monomorphic (mkName x))) |] ]
-         else return []
+         else warning x >> return []
   [| runQuickCheckAll $(fmap (ListE . concat) (mapM quickCheckOne idents)) |]
 
 readUTF8File name = S.openFile name S.ReadMode >>=


### PR DESCRIPTION
`reify` for locally defined names (in the same module as the splice) isn't
supported in GHC 7.8 anymore, so it fails. But we can still use 
lookupValueName, which returns Nothing if the name doesn't exist.
