### PR TITLE
More idiomatic implementation of 'vectorOf'

### DIFF
--- a/Test/QuickCheck/Gen.hs
+++ b/Test/QuickCheck/Gen.hs
@@ -19,6 +19,7 @@ import System.Random
 import Control.Monad
   ( liftM
   , ap
+  , replicateM
   )
 
 import Control.Applicative


### PR DESCRIPTION
Note that `replicateM` is present in `base` since August 2002 (https://github.com/ghc/ghc/blob/e2e8a57360669da00a8bee6491b708896fbe168e/libraries/base/Control/Monad.hs).
