### PR TITLE
Disable the test suite without templateHaskell

### DIFF
--- a/QuickCheck.cabal
+++ b/QuickCheck.cabal
@@ -144,3 +144,8 @@ Test-Suite test-quickcheck
       QuickCheck == 2.7.6,
       template-haskell >= 2.4,
       test-framework >= 0.4 && < 0.9
+    if flag(templateHaskell)
+        Buildable: True
+    else
+        Buildable: False
+


### PR DESCRIPTION
As the test suite uses Test.QuickCheck.All
