### PR TITLE
Allow single star-kinded TyVarBndrs in quickCheckAll

### DIFF
--- a/Test/QuickCheck/All.hs
+++ b/Test/QuickCheck/All.hs
@@ -79,8 +79,13 @@ infoType (VarI _ ty _ _) = ty
 
 deconstructType :: Error -> Type -> Q ([Name], Cxt, Type)
 deconstructType err ty0@(ForallT xs ctx ty) = do
-  let plain (PlainTV _) = True
-      plain _ = False
+  let plain (PlainTV  _)       = True
+#if MIN_VERSION_template_haskell(2,8,0)
+      plain (KindedTV _ StarT) = True
+#else
+      plain (KindedTV _ StarK) = True
+#endif
+      plain _                  = False
   unless (all plain xs) $ err "Higher-kinded type variables in type"
   return (map (\(PlainTV x) -> x) xs, ctx, ty)
 deconstructType _ ty = return ([], [], ty)


### PR DESCRIPTION
This pull request was motivated when I tried using `quickCheckAll` in GHC 7.10, which uses `tempate-haskell-2.10.0.0`. Introduced in `template-haskell-2.10.0.0` was [a change](https://downloads.haskell.org/~ghc/7.10.1-rc1/docs/html/users_guide/release-7-10-1.html#idp5794496) in which all reified `TyVarBndr`s are now `KindedTV`s. This causes some `QuickCheck` code which worked in previous GHCs to fail with GHC 7.10. As an example, when you run this code on GHC 7.10:

```haskell
{-# LANGUAGE TemplateHaskell #-}
module Main (main) where

import Test.QuickCheck (Arbitrary, quickCheckAll)

prop_elem :: (Arbitrary a, Eq a, Show a) => a -> [a] -> Bool
prop_elem a as = a `elem` as

$(return [])

main :: IO ()
main = $quickCheckAll >>= print
```
you encounter this error:

```
    Exception when trying to run compile-time code:
      Higher-kinded type variables in type: forall (a_0 :: *) . (Test.QuickCheck.Arbitrary.Arbitrary a_0,
                     GHC.Classes.Eq a_0,
                     GHC.Show.Show a_0) =>
                    a_0 -> [a_0] -> GHC.Types.Bool
    Code: quickCheckAll
    In the splice: $quickCheckAll
```

Clearly, `a` is not higher-kinded, but `deconstructType` from `Test.QuickCheck.All` assumes all `KindedTV`s are higher-kinded.

The easiest solution to this problem seems to be simply extending `deconstructType` to recognize that `KindedTV`s with a `StarT` kind (or a `StarK` kind, if using an older version of `template-haskell`) are in fact plain type constructors. This hopefully shouldn't be a breaking change.