### PR TITLE
In quickCheckAll, when a tyvar uses KindedTV, check the kind

### DIFF
--- a/Test/QuickCheck/All.hs
+++ b/Test/QuickCheck/All.hs
@@ -80,6 +80,7 @@ infoType (VarI _ ty _ _) = ty
 deconstructType :: Error -> Type -> Q ([Name], Cxt, Type)
 deconstructType err ty0@(ForallT xs ctx ty) = do
   let plain (PlainTV _) = True
+      plain (KindedTV _ StarT) = True
       plain _ = False
   unless (all plain xs) $ err "Higher-kinded type variables in type"
   return (map (\(PlainTV x) -> x) xs, ctx, ty)


### PR DESCRIPTION
It might not really be higher-kinded.

I ran into this on the GHC 7.10 RC, which has a new version of TH (2.10). You *might* be able to call this a bug in TH, and if not a bug, it's certainly an annoying change in behavior.

Also, I am not sure if my patch is general enough. Should a kind like `AppT StarT StarT` be considered plain for QuickCheck's purposes?

The test suite passes with this patch.