### PR TITLE
Fix a GHC 7.10 warning.

### DIFF
--- a/Test/QuickCheck/Arbitrary.hs
+++ b/Test/QuickCheck/Arbitrary.hs
@@ -3,7 +3,10 @@
 #ifndef NO_GENERICS
 {-# LANGUAGE DefaultSignatures, FlexibleContexts, TypeOperators #-}
 {-# LANGUAGE FlexibleInstances, KindSignatures, ScopedTypeVariables #-}
-{-# LANGUAGE MultiParamTypeClasses, OverlappingInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+#if __GLASGOW_HASKELL__ < 710
+{-# LANGUAGE OverlappingInstances  #-}
+#endif
 #endif
 #ifndef NO_SAFE_HASKELL
 {-# LANGUAGE Safe #-}


### PR DESCRIPTION
`-XOverlappedInstances` is deprecated and is actually unnecessary here, at least on 7.10.