### PR TITLE
Distinguish between variables and constructors

### DIFF
--- a/Test/QuickCheck/All.hs
+++ b/Test/QuickCheck/All.hs
@@ -66,11 +66,20 @@ monomorphic t = do
   let err msg = error $ msg ++ ": " ++ pprint ty0
   (polys, ctx, ty) <- deconstructType err ty0
   case polys of
-    [] -> return (VarE t)
+    [] -> return (expName t)
     _ -> do
       integer <- [t| Integer |]
       ty' <- monomorphiseType err integer ty
-      return (SigE (VarE t) ty')
+      return (SigE (expName t) ty')
+
+expName :: Name -> Exp
+expName n = if isVar n then VarE n else ConE n
+
+-- See section 2.4 of the Haskell 2010 Language Report, plus support for "[]"
+isVar :: Name -> Bool
+isVar = let isVar' (c:_) = not (isUpper c || c `elem` ":[")
+            isVar' _     = True
+        in isVar' . nameBase
 
 infoType :: Info -> Type
 #if __GLASGOW_HASKELL__ >= 711

--- a/tests/Weird.hs
+++ b/tests/Weird.hs
@@ -70,5 +70,14 @@ prop_forevershrink2' C1 = False
 prop_forevershrink2' C2 = False
 prop_forevershrink2' C3 = prop_forevershrink2' C3
 
+-- Test automatic monomorphism
+prop_poly :: [a] -> Bool
+prop_poly a = length a >= 0
+
+-- See if monomorphic accepts constructor names
+dummyRun = quickCheck $(monomorphic 'True)
+monoNil  = $(monomorphic '[])
+monoCons = $(monomorphic '(:))
+
 return []
 main = $quickCheckAll -- UTF8 test: Привет!


### PR DESCRIPTION
Fixes #63

Test by loading `tests/Weird.hs` in GHCi; each of the following cases will be run by TemplateHaskell, failing with an error if any isn't right:

 - Monomorphising polymorphic variables, via `$quickCheckAll`. This is the existing behaviour, although it seemed to be untested. I've added `prop_poly` to test this.
 - Monomorphising prefix data constructors. I've added `dummyRun` to test this.
 - Monomorphising infix data constructors, ie. those which begin with `:`. I've added `monoCons` to test this.
 - Monomorphising `[]`, which seems to defy the prefix and infix rules given in the Haskell 2010 Language Report. I've added `monoNil` to test this.

There are no regressions from `cabal test`, although that only seems to run one of the examples.

This was tested with GHC 7.10.2 on NixOS Linux x86.