### PR TITLE
Add build flag to disable TFGen

### DIFF
--- a/QuickCheck.cabal
+++ b/QuickCheck.cabal
@@ -124,7 +124,7 @@ library
   if impl (ghc < 7.4)
     cpp-options: -DNO_SAFE_HASKELL
 
-  -- Use tf-random on newer GHCs. Build with noTDRandom flag to disable.
+  -- Use tf-random on newer GHCs. Build with noTFRandom flag to disable.
   if !flag(noTFRandom) && impl(ghc >= 7) && (flag(base4point8) || flag(base4))
     Build-depends: tf-random >= 0.4
   else

--- a/QuickCheck.cabal
+++ b/QuickCheck.cabal
@@ -51,6 +51,9 @@ flag base4point8
 flag templateHaskell
   Description: Build Test.QuickCheck.All, which uses Template Haskell.
 
+flag noTFRandom
+  Description: Forces StdGen to be used instead of TFGen.
+
 library
   -- Choose which library versions to use.
   if flag(base4point8)
@@ -121,8 +124,8 @@ library
   if impl (ghc < 7.4)
     cpp-options: -DNO_SAFE_HASKELL
 
-  -- Use tf-random on newer GHCs.
-  if impl(ghc >= 7) && (flag(base4point8) || flag(base4))
+  -- Use tf-random on newer GHCs. Build with noTDRandom flag to disable.
+  if !flag(noTFRandom) && impl(ghc >= 7) && (flag(base4point8) || flag(base4))
     Build-depends: tf-random >= 0.4
   else
     cpp-options: -DNO_TF_RANDOM


### PR DESCRIPTION
I'd like to make a tool that makes it possible to build tests that compare function outputs from multiple Haskell backends against each other, in order to ensure consistent behavior on multiple backends. Currently I can't use Arbitrary for this tool, because I need to ensure that the randomized output is the same on all backends, Adding a build flag to disable TFGen should make this possible, albeit somewhat hacky since I have to somehow ensure that QuickCheck was always built with this flag. Perhaps it would be better to instead make it possible to choose exactly which generator to use? This could be done, for example, by using a SomeGen existential, but that would require the use of language extensions. Is there another way to allow this?
