### PR TITLE
Make compatible with template-haskell 2.11 / GHC 8.0

### DIFF
--- a/QuickCheck.cabal
+++ b/QuickCheck.cabal
@@ -50,6 +50,7 @@ flag base4point8
 
 flag templateHaskell
   Description: Build Test.QuickCheck.All, which uses Template Haskell.
+  Default: True
 
 library
   -- Choose which library versions to use.
@@ -92,6 +93,7 @@ library
     cpp-options: -DNO_TRANSFORMERS
   if impl(ghc >= 6.12) && flag(templateHaskell)
     Build-depends: template-haskell >= 2.4
+    Other-Extensions: TemplateHaskell
     Exposed-Modules: Test.QuickCheck.All
   else
     cpp-options: -DNO_TEMPLATE_HASKELL

--- a/Test/QuickCheck/All.hs
+++ b/Test/QuickCheck/All.hs
@@ -2,6 +2,13 @@
 #ifndef NO_SAFE_HASKELL
 {-# LANGUAGE Trustworthy #-}
 #endif
+
+#ifndef MIN_VERSION_template_haskell
+-- Fun-fact: GHC 8.0+ provides MIN_VERSION_template_haskell()
+-- automatically iff `-package` flags are passed on the commandline
+#define MIN_VERSION_template_haskell(a,b,c) 1
+#endif
+
 -- | Test all properties in the current module, using Template Haskell.
 -- You need to have a @{-\# LANGUAGE TemplateHaskell \#-}@ pragma in
 -- your module for any of these to work.
@@ -73,21 +80,23 @@ monomorphic t = do
       return (SigE (VarE t) ty')
 
 infoType :: Info -> Type
+#if MIN_VERSION_template_haskell(2,11,0)
+infoType (ClassOpI _ ty _) = ty
+infoType (DataConI _ ty _) = ty
+infoType (VarI     _ ty _) = ty
+#else
 infoType (ClassOpI _ ty _ _) = ty
 infoType (DataConI _ ty _ _) = ty
-infoType (VarI _ ty _ _) = ty
+infoType (VarI     _ ty _ _) = ty
+#endif
 
 deconstructType :: Error -> Type -> Q ([Name], Cxt, Type)
 deconstructType err ty0@(ForallT xs ctx ty) = do
   let plain (PlainTV  _)       = True
-#ifndef MIN_VERSION_template_haskell
-      plain (KindedTV _ StarT) = True
-#else
 #if MIN_VERSION_template_haskell(2,8,0)
       plain (KindedTV _ StarT) = True
 #else
       plain (KindedTV _ StarK) = True
-#endif
 #endif
       plain _                  = False
   unless (all plain xs) $ err "Higher-kinded type variables in type"


### PR DESCRIPTION
While at it, this also makes the QuickCheck package convenient for
unregisterised and/or cross-compilers lacking TH support with latest
Cabal solvers by declaring the need for Template-Haskell in
`other-extensions` as a dependency, which then directs the cabal solver
toggle off the TH support flag if that extension is not advertised by
GHC.