### PR TITLE
Write specialized instance for sequences

### DIFF
--- a/Test/QuickCheck/Gen.hs
+++ b/Test/QuickCheck/Gen.hs
@@ -35,6 +35,7 @@ import Control.Arrow
 import Test.QuickCheck.Random
 import Data.List
 import Data.Ord
+import qualified Data.Sequence as Seq
 
 --------------------------------------------------------------------------
 -- ** Generator type
@@ -202,6 +203,17 @@ vectorOf = replicateM
 -- | Generates an infinite list.
 infiniteListOf :: Gen a -> Gen [a]
 infiniteListOf gen = sequence (repeat gen)
+
+-- | Generates a sequence of random length. The maximum length depends
+-- on the size parameter.
+seqOf :: Gen a -> Gen (Seq.Seq a)
+seqOf gen = sized $ \n ->
+  do k <- choose (0,n)
+     seqOfSize k gen
+
+-- | Generates a sequence of the given length.
+seqOfSize :: Int -> Gen a -> Gen (Seq.Seq a)
+seqOfSize = Seq.replicateA
 
 --------------------------------------------------------------------------
 -- the end.


### PR DESCRIPTION
Replace list-based `Arbitrary` instance with one using
primitives from `Data.Sequence`. This avoids the inefficiency
of `fromList` in general, and takes advantage of fast splitting
and appending.

Note: there may well be a way to improve shrinking further;
this commit simply translates the version for lists into
the language of sequences.
