### PR TITLE
Base instances

### DIFF
--- a/Test/QuickCheck/Arbitrary.hs
+++ b/Test/QuickCheck/Arbitrary.hs
@@ -1,6 +1,11 @@
 -- | Type classes for random generation of values.
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
+#ifdef MIN_VERSION_base
+#if MIN_VERSION_base(4,7,0)
+{-# LANGUAGE PolyKinds #-}
+#endif
+#endif
 #ifndef NO_GENERICS
 {-# LANGUAGE DefaultSignatures, FlexibleContexts, TypeOperators #-}
 {-# LANGUAGE FlexibleInstances, KindSignatures, ScopedTypeVariables #-}
@@ -123,8 +128,15 @@ import Control.Monad
 import Data.Int(Int8, Int16, Int32, Int64)
 import Data.Word(Word, Word8, Word16, Word32, Word64)
 import System.Exit (ExitCode(..))
+#ifdef MIN_VERSION_base
 #if MIN_VERSION_base(4,5,0)
 import Foreign.C.Types
+#endif
+#endif
+#ifdef MIN_VERSION_base
+#if MIN_VERSION_base(4,7,0)
+import Data.Typeable (Proxy(..))
+#endif
 #endif
 
 #ifndef NO_GENERICS
@@ -803,6 +815,13 @@ instance Arbitrary ExitCode where
 
   shrink (ExitFailure x) = ExitSuccess : [ ExitFailure x' | x' <- shrink x ]
   shrink _        = []
+
+#if defined(MIN_VERSION_base)
+#if MIN_VERSION_base(4,7,0)
+instance Arbitrary (Proxy a) where
+  arbitrary = return Proxy
+#endif
+#endif
 
 
 -- ** Helper functions for implementing arbitrary

--- a/Test/QuickCheck/Arbitrary.hs
+++ b/Test/QuickCheck/Arbitrary.hs
@@ -123,7 +123,7 @@ import Control.Monad
 import Data.Int(Int8, Int16, Int32, Int64)
 import Data.Word(Word, Word8, Word16, Word32, Word64)
 import System.Exit (ExitCode(..))
-#if MIN_VERSION_base(4,4,0)
+#if MIN_VERSION_base(4,5,0)
 import Foreign.C.Types
 #endif
 
@@ -593,7 +593,7 @@ instance Arbitrary Double where
   arbitrary = arbitrarySizedFractional
   shrink    = shrinkRealFrac
 
-#if MIN_VERSION_base(4,4,0)
+#if MIN_VERSION_base(4,5,0)
 instance Arbitrary CChar where
   arbitrary = CChar <$> arbitrary
   shrink (CChar x) = CChar <$> shrink x

--- a/Test/QuickCheck/Arbitrary.hs
+++ b/Test/QuickCheck/Arbitrary.hs
@@ -121,8 +121,10 @@ import Control.Monad
 
 import Data.Int(Int8, Int16, Int32, Int64)
 import Data.Word(Word, Word8, Word16, Word32, Word64)
-import Foreign.C.Types
 import System.Exit (ExitCode(..))
+#if MIN_VERSION_base(4,4,0)
+import Foreign.C.Types
+#endif
 
 #ifndef NO_GENERICS
 import GHC.Generics
@@ -590,6 +592,7 @@ instance Arbitrary Double where
   arbitrary = arbitrarySizedFractional
   shrink    = shrinkRealFrac
 
+#if MIN_VERSION_base(4,4,0)
 instance Arbitrary CChar where
   arbitrary = CChar <$> arbitrary
   shrink (CChar x) = CChar <$> shrink x
@@ -689,7 +692,7 @@ instance Arbitrary CFloat where
 instance Arbitrary CDouble where
   arbitrary = CDouble <$> arbitrary
   shrink (CDouble x) = CDouble <$> shrink x
-
+#endif
 
 -- Arbitrary instances for container types
 instance (Ord a, Arbitrary a) => Arbitrary (Set.Set a) where

--- a/Test/QuickCheck/Arbitrary.hs
+++ b/Test/QuickCheck/Arbitrary.hs
@@ -122,6 +122,7 @@ import Control.Monad
 import Data.Int(Int8, Int16, Int32, Int64)
 import Data.Word(Word, Word8, Word16, Word32, Word64)
 import Foreign.C.Types
+import System.Exit (ExitCode(..))
 
 #ifndef NO_GENERICS
 import GHC.Generics
@@ -784,6 +785,13 @@ instance Arbitrary Version where
     , length xs' > 0
     , all (>=0) xs'
     ]
+
+instance Arbitrary ExitCode where
+  arbitrary = frequency [(1, return ExitSuccess), (3, liftM ExitFailure arbitrary)]
+
+  shrink (ExitFailure x) = ExitSuccess : [ ExitFailure x' | x' <- shrink x ]
+  shrink _        = []
+
 
 -- ** Helper functions for implementing arbitrary
 

--- a/Test/QuickCheck/Arbitrary.hs
+++ b/Test/QuickCheck/Arbitrary.hs
@@ -727,6 +727,14 @@ instance Arbitrary a => Arbitrary (Const a b) where
   arbitrary = fmap Const arbitrary
   shrink = map Const . shrink . getConst
 
+instance Arbitrary (m a) => Arbitrary (WrappedMonad m a) where
+  arbitrary = WrapMonad <$> arbitrary
+  shrink (WrapMonad a) = map WrapMonad (shrink a)
+
+instance Arbitrary (a b c) => Arbitrary (WrappedArrow a b c) where
+  arbitrary = WrapArrow <$> arbitrary
+  shrink (WrapArrow a) = map WrapArrow (shrink a)
+
 -- Arbitrary instances for Monoid
 instance Arbitrary a => Arbitrary (Monoid.Dual a) where
   arbitrary = fmap Monoid.Dual arbitrary

--- a/Test/QuickCheck/Arbitrary.hs
+++ b/Test/QuickCheck/Arbitrary.hs
@@ -1,5 +1,6 @@
 -- | Type classes for random generation of values.
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
 #ifndef NO_GENERICS
 {-# LANGUAGE DefaultSignatures, FlexibleContexts, TypeOperators #-}
 {-# LANGUAGE FlexibleInstances, KindSignatures, ScopedTypeVariables #-}

--- a/Test/QuickCheck/Arbitrary.hs
+++ b/Test/QuickCheck/Arbitrary.hs
@@ -121,6 +121,7 @@ import Control.Monad
 
 import Data.Int(Int8, Int16, Int32, Int64)
 import Data.Word(Word, Word8, Word16, Word32, Word64)
+import Foreign.C.Types
 
 #ifndef NO_GENERICS
 import GHC.Generics
@@ -587,6 +588,107 @@ instance Arbitrary Float where
 instance Arbitrary Double where
   arbitrary = arbitrarySizedFractional
   shrink    = shrinkRealFrac
+
+instance Arbitrary CChar where
+  arbitrary = CChar <$> arbitrary
+  shrink (CChar x) = CChar <$> shrink x
+
+instance Arbitrary CSChar where
+  arbitrary = CSChar <$> arbitrary
+  shrink (CSChar x) = CSChar <$> shrink x
+
+instance Arbitrary CUChar where
+  arbitrary = CUChar <$> arbitrary
+  shrink (CUChar x) = CUChar <$> shrink x
+
+instance Arbitrary CShort where
+  arbitrary = CShort <$> arbitrary
+  shrink (CShort x) = CShort <$> shrink x
+
+instance Arbitrary CUShort where
+  arbitrary = CUShort <$> arbitrary
+  shrink (CUShort x) = CUShort <$> shrink x
+
+instance Arbitrary CInt where
+  arbitrary = CInt <$> arbitrary
+  shrink (CInt x) = CInt <$> shrink x
+
+instance Arbitrary CUInt where
+  arbitrary = CUInt <$> arbitrary
+  shrink (CUInt x) = CUInt <$> shrink x
+
+instance Arbitrary CLong where
+  arbitrary = CLong <$> arbitrary
+  shrink (CLong x) = CLong <$> shrink x
+
+instance Arbitrary CULong where
+  arbitrary = CULong <$> arbitrary
+  shrink (CULong x) = CULong <$> shrink x
+
+instance Arbitrary CPtrdiff where
+  arbitrary = CPtrdiff <$> arbitrary
+  shrink (CPtrdiff x) = CPtrdiff <$> shrink x
+
+instance Arbitrary CSize where
+  arbitrary = CSize <$> arbitrary
+  shrink (CSize x) = CSize <$> shrink x
+
+instance Arbitrary CWchar where
+  arbitrary = CWchar <$> arbitrary
+  shrink (CWchar x) = CWchar <$> shrink x
+
+instance Arbitrary CSigAtomic where
+  arbitrary = CSigAtomic <$> arbitrary
+  shrink (CSigAtomic x) = CSigAtomic <$> shrink x
+
+instance Arbitrary CLLong where
+  arbitrary = CLLong <$> arbitrary
+  shrink (CLLong x) = CLLong <$> shrink x
+
+instance Arbitrary CULLong where
+  arbitrary = CULLong <$> arbitrary
+  shrink (CULLong x) = CULLong <$> shrink x
+
+instance Arbitrary CIntPtr where
+  arbitrary = CIntPtr <$> arbitrary
+  shrink (CIntPtr x) = CIntPtr <$> shrink x
+
+instance Arbitrary CUIntPtr where
+  arbitrary = CUIntPtr <$> arbitrary
+  shrink (CUIntPtr x) = CUIntPtr <$> shrink x
+
+instance Arbitrary CIntMax where
+  arbitrary = CIntMax <$> arbitrary
+  shrink (CIntMax x) = CIntMax <$> shrink x
+
+instance Arbitrary CUIntMax where
+  arbitrary = CUIntMax <$> arbitrary
+  shrink (CUIntMax x) = CUIntMax <$> shrink x
+
+instance Arbitrary CClock where
+  arbitrary = CClock <$> arbitrary
+  shrink (CClock x) = CClock <$> shrink x
+
+instance Arbitrary CTime where
+  arbitrary = CTime <$> arbitrary
+  shrink (CTime x) = CTime <$> shrink x
+
+instance Arbitrary CUSeconds where
+  arbitrary = CUSeconds <$> arbitrary
+  shrink (CUSeconds x) = CUSeconds <$> shrink x
+
+instance Arbitrary CSUSeconds where
+  arbitrary = CSUSeconds <$> arbitrary
+  shrink (CSUSeconds x) = CSUSeconds <$> shrink x
+
+instance Arbitrary CFloat where
+  arbitrary = CFloat <$> arbitrary
+  shrink (CFloat x) = CFloat <$> shrink x
+
+instance Arbitrary CDouble where
+  arbitrary = CDouble <$> arbitrary
+  shrink (CDouble x) = CDouble <$> shrink x
+
 
 -- Arbitrary instances for container types
 instance (Ord a, Arbitrary a) => Arbitrary (Set.Set a) where


### PR DESCRIPTION
Add missing Arbitrary instances for data types from base
- Data types from Foreign.C.Types
- System.Exit.ExitCode
- WrappedMonad and WrappedArrow
