### PR TITLE
Don't depend on Template Haskell or tf-random when installed using Haste.

### DIFF
--- a/QuickCheck.cabal
+++ b/QuickCheck.cabal
@@ -69,7 +69,7 @@ library
   else
     cpp-options: -DNO_TRANSFORMERS
 
-  if impl(ghc) && flag(templateHaskell)
+  if impl(ghc) && flag(templateHaskell) && !impl(haste)
     Build-depends: template-haskell >= 2.4
     Other-Extensions: TemplateHaskell
     Exposed-Modules: Test.QuickCheck.All
@@ -88,7 +88,7 @@ library
     cpp-options: -DNO_SAFE_HASKELL
 
   -- Use tf-random on newer GHCs.
-  if impl(ghc)
+  if impl(ghc) && !impl(haste)
     Build-depends: tf-random >= 0.4
   else
     cpp-options: -DNO_TF_RANDOM
@@ -137,7 +137,7 @@ Test-Suite test-quickcheck
       QuickCheck == 2.8.2,
       template-haskell >= 2.4,
       test-framework >= 0.4 && < 0.9
-    if flag(templateHaskell)
+    if flag(templateHaskell) && !impl(haste)
         Buildable: True
     else
         Buildable: False
@@ -157,7 +157,7 @@ Test-Suite test-quickcheck-generators
     hs-source-dirs: tests
     main-is: Generators.hs
     build-depends: base, QuickCheck == 2.8.2
-    if !flag(templateHaskell)
+    if !flag(templateHaskell) || impl(haste)
         Buildable: False
 
 Test-Suite test-quickcheck-gshrink


### PR DESCRIPTION
Haste is offended by C dependencies and Template Haskell, so let's shut them off when building with Haste.