### PR TITLE
Fix a spaceleak with label function

### DIFF
--- a/Test/QuickCheck/Test.hs
+++ b/Test/QuickCheck/Test.hs
@@ -17,7 +17,7 @@ import qualified Test.QuickCheck.State as S
 import Test.QuickCheck.Exception
 import Test.QuickCheck.Random
 import System.Random(split)
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 
 import Data.Char


### PR DESCRIPTION
There is a space leak with the label function. Specifically, given the following program:

```
{-# LANGUAGE ScopedTypeVariables #-}
import Test.QuickCheck
main :: IO ()
main = do
    Success{} <- quickCheckWithResult stdArgs{maxSuccess=10000} $ \(p :: Double) -> label "foo" True
    print "done"
```

Running it I get:

```
$ ghc --make Main.hs -rtsopts && Main +RTS -K1K
...
Linking Main.exe ...
Main: Stack space overflow: current size 33624 bytes.
Main: Use `+RTS -Ksize -RTS' to increase it.
```

The `-K1K` flag limits the stack, which makes it easier to detect the space leak. Under normal circumstances it just increases memory usage and makes things go unnecessarily slower without failing.

After applying the patch the space leak disappears. Originally spotted by @jacereda and reported at https://github.com/ndmitchell/shake/issues/450.