### PR TITLE
Add "again" to "forAll"

### DIFF
--- a/Test/QuickCheck/Property.hs
+++ b/Test/QuickCheck/Property.hs
@@ -414,6 +414,7 @@ within n = mapRoseResult f
 forAll :: (Show a, Testable prop)
        => Gen a -> (a -> prop) -> Property
 forAll gen pf =
+  again $
   MkProperty $
   gen >>= \x ->
     unProperty (counterexample (show x) (pf x))


### PR DESCRIPTION
Haven't tested this but in the latest version this only executes once

```haskell
>>> verboseCheck $ forAll (arbitrarySizedBoundedIntegral @Int) (\x -> x /= minBound)
Passed:  
1
+++ OK, passed 1 tests. 
```

I have to use `again`, seems it was forgotten

```haskell
>>> quickCheck $ again $ forAll (arbitrarySizedBoundedIntegral @Int) (\x -> x /= minBound)
+++ OK, passed 100 tests.
```