### PR TITLE
Export fun

### DIFF
--- a/Test/QuickCheck.hs
+++ b/Test/QuickCheck.hs
@@ -176,10 +176,10 @@ module Test.QuickCheck
 
     -- ** Functions
   , Fun
+  , appFun
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 708
   , pattern Fn
 #endif
-  , apply
   , Function (..)
   , functionMap
 

--- a/Test/QuickCheck.hs
+++ b/Test/QuickCheck.hs
@@ -69,6 +69,9 @@ showable functions used for testing higher-order functions and
 #ifndef NO_SAFE_HASKELL
 {-# LANGUAGE Safe #-}
 #endif
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE PatternSynonyms #-}
+#endif
 module Test.QuickCheck
   (
     -- * Running tests
@@ -171,6 +174,15 @@ module Test.QuickCheck
   , ShrinkState(..)
 #endif
 
+    -- ** Functions
+  , Fun
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 708
+  , pattern Fn
+#endif
+  , apply
+  , Function (..)
+  , functionMap
+
     -- * Properties
   , Property, Testable(..)
     -- ** Property combinators
@@ -220,6 +232,7 @@ import Test.QuickCheck.Property hiding ( Result(..) )
 import Test.QuickCheck.Test
 import Test.QuickCheck.Text
 import Test.QuickCheck.Exception
+import Test.QuickCheck.Function
 #ifndef NO_TEMPLATE_HASKELL
 import Test.QuickCheck.All
 #endif

--- a/Test/QuickCheck/Function.hs
+++ b/Test/QuickCheck/Function.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE TypeOperators, GADTs, CPP #-}
-
+#ifndef NO_SAFE_HASKELL
+{-# LANGUAGE Safe #-}
+#endif
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 708
 {-# LANGUAGE PatternSynonyms, ViewPatterns #-}
 #endif

--- a/Test/QuickCheck/Function.hs
+++ b/Test/QuickCheck/Function.hs
@@ -34,10 +34,14 @@
 -- See the @'Function' [a]@ instance for an example of the latter.
 module Test.QuickCheck.Function
   ( Fun(..)
+<<<<<<< HEAD
 #if __GLASGOW_HASKELL__ >= 800
   , Fun2
   , Fun3
 #endif
+=======
+  , appFun
+>>>>>>> 2890938... Add appFun
   , apply
   , apply2
   , apply3
@@ -523,15 +527,19 @@ curry3 f a b c = f (a, b, c)
 mkFun :: (a :-> b) -> b -> Fun a b
 mkFun p d = Fun (p, d, NotShrunk) (abstract p d)
 
--- | Extracts the function value.
+-- | Alias to 'appFun'.
+apply :: Fun a b -> (a -> b)
+apply = appFun
+
+-- | Extracts the function value. 
 --
 -- 'Fn' is the pattern equivalent of this function.
 --
 -- > prop :: Fun String Integer -> Bool
--- > prop f = apply f "banana" == apply f "monkey"
--- >       || apply f "banana" == apply f "elephant"
-apply :: Fun a b -> (a -> b)
-apply (Fun _ f) = f
+-- > prop f = appFun f "banana" == appFun f "monkey"
+-- >       || appFun f "banana" == appFun f "elephant"
+appFun :: Fun a b -> (a -> b)
+appFun (Fun _ f) = f
 
 -- | Extracts the binary function value.
 --

--- a/Test/QuickCheck/Function.hs
+++ b/Test/QuickCheck/Function.hs
@@ -472,6 +472,12 @@ shrinkFun shr (Map g h p) =
 --------------------------------------------------------------------------
 -- the Fun modifier
 
+-- | Generation of random shrinkable, showable functions.
+--
+-- To generate random values of type @'Fun' a b@,
+-- you must have an instance @'Function' a@.
+--
+-- See also 'apply' (and 'Fn' with GHC >= 7.8)
 data Fun a b = Fun (a :-> b, b, Shrunk) (a -> b)
 data Shrunk = Shrunk | NotShrunk deriving Eq
 #if __GLASGOW_HASKELL__ >= 800
@@ -520,6 +526,10 @@ mkFun p d = Fun (p, d, NotShrunk) (abstract p d)
 -- | Extracts the function value.
 --
 -- 'Fn' is the pattern equivalent of this function.
+--
+-- > prop :: Fun String Integer -> Bool
+-- > prop f = apply f "banana" == apply f "monkey"
+-- >       || apply f "banana" == apply f "elephant"
 apply :: Fun a b -> (a -> b)
 apply (Fun _ f) = f
 

--- a/Test/QuickCheck/Function.hs
+++ b/Test/QuickCheck/Function.hs
@@ -34,14 +34,11 @@
 -- See the @'Function' [a]@ instance for an example of the latter.
 module Test.QuickCheck.Function
   ( Fun(..)
-<<<<<<< HEAD
 #if __GLASGOW_HASKELL__ >= 800
   , Fun2
   , Fun3
 #endif
-=======
   , appFun
->>>>>>> 2890938... Add appFun
   , apply
   , apply2
   , apply3

--- a/Test/QuickCheck/Function.hs
+++ b/Test/QuickCheck/Function.hs
@@ -501,15 +501,15 @@ pattern Fn :: (a -> b) -> Fun a b
 pattern Fn f <- Fun _ f
 
 -- | A modifier for testing binary functions.
--- 
--- @ 
+--
+-- @
 --     prop_zipWith :: Fun (Int, Bool) Char -> [Int] -> [Bool] -> Bool
 --     prop_zipWith (Fn2 f) xs ys = zipWith f xs ys == [ f x y | (x, y) <- zip xs ys]
 -- @
 --
 -- >>> quickCheck prop_zipWith
 -- +++ OK, passed 100 tests.
--- 
+--
 #if __GLASGOW_HASKELL__ >= 800
 pattern Fn2 :: (a -> b -> c) -> Fun2 a b c
 #endif
@@ -531,7 +531,7 @@ mkFun p d = Fun (p, d, NotShrunk) (abstract p d)
 apply :: Fun a b -> (a -> b)
 apply = appFun
 
--- | Extracts the function value. 
+-- | Extracts the function value.
 --
 -- 'Fn' is the pattern equivalent of this function.
 --
@@ -549,8 +549,8 @@ apply2 (Fun _ f) a b = f (a, b)
 
 -- | Extracts the value of a function of three arguments. 'Fn3' is the
 -- pattern equivalent of this function.
--- 
--- @ 
+--
+-- @
 --     prop_zipWith :: Fun (Int, Bool) Char -> [Int] -> [Bool] -> Bool
 --     prop_zipWith f xs ys = zipWith (apply f) xs ys == [ (apply f) x y | (x, y) <- zip xs ys]
 -- @

--- a/Test/QuickCheck/Gen/Unsafe.hs
+++ b/Test/QuickCheck/Gen/Unsafe.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE CPP #-}
+#ifndef NO_SAFE_HASKELL
+{-# LANGUAGE Safe #-}
+#endif
 #ifndef NO_ST_MONAD
 {-# LANGUAGE Rank2Types #-}
 #endif

--- a/Test/QuickCheck/Monadic.hs
+++ b/Test/QuickCheck/Monadic.hs
@@ -1,4 +1,11 @@
 {-# LANGUAGE CPP #-}
+#ifndef NO_SAFE_HASKELL
+#if !defined(NO_ST_MONAD) && !(MIN_VERSION_base(4,8,0))
+{-# LANGUAGE Trustworthy #-}
+#else
+{-# LANGUAGE Safe #-}
+#endif
+#endif
 #ifndef NO_ST_MONAD
 {-# LANGUAGE Rank2Types #-}
 #endif

--- a/Test/QuickCheck/Poly.hs
+++ b/Test/QuickCheck/Poly.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
-#ifndef NO_NEWTYPE_DERIVING
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+#ifndef NO_SAFE_HASKELL
+{-# LANGUAGE Safe #-}
 #endif
 -- | Types to help with testing polymorphic properties.
 --
@@ -75,11 +75,27 @@ instance CoArbitrary C where
 -- OrdA
 
 newtype OrdA = OrdA{ unOrdA :: Integer }
-  deriving ( Eq, Ord
-#ifndef NO_NEWTYPE_DERIVING
-           , Num
-#endif
-           )
+  deriving ( Eq, Ord )
+
+liftOrdA
+    :: (Integer -> Integer)
+    -> OrdA -> OrdA
+liftOrdA f (OrdA x) = OrdA (f x)
+
+liftOrdA2
+    :: (Integer -> Integer -> Integer)
+    -> OrdA -> OrdA -> OrdA
+liftOrdA2 f (OrdA x) (OrdA y) = OrdA (f x y)
+
+instance Num OrdA where
+    (+)         = liftOrdA2 (+)
+    (*)         = liftOrdA2 (*)
+    (-)         = liftOrdA2 (-)
+    negate      = liftOrdA negate
+    abs         = liftOrdA abs
+    signum      = liftOrdA signum
+    fromInteger = OrdA . fromInteger
+
 
 instance Show OrdA where
   showsPrec n (OrdA x) = showsPrec n x
@@ -94,11 +110,26 @@ instance CoArbitrary OrdA where
 -- OrdB
 
 newtype OrdB = OrdB{ unOrdB :: Integer }
-  deriving ( Eq, Ord
-#ifndef NO_NEWTYPE_DERIVING
-           , Num
-#endif
-           )
+  deriving ( Eq, Ord )
+
+liftOrdB
+    :: (Integer -> Integer)
+    -> OrdB -> OrdB
+liftOrdB f (OrdB x) = OrdB (f x)
+
+liftOrdB2
+    :: (Integer -> Integer -> Integer)
+    -> OrdB -> OrdB -> OrdB
+liftOrdB2 f (OrdB x) (OrdB y) = OrdB (f x y)
+
+instance Num OrdB where
+    (+)         = liftOrdB2 (+)
+    (*)         = liftOrdB2 (*)
+    (-)         = liftOrdB2 (-)
+    negate      = liftOrdB negate
+    abs         = liftOrdB abs
+    signum      = liftOrdB signum
+    fromInteger = OrdB . fromInteger
 
 instance Show OrdB where
   showsPrec n (OrdB x) = showsPrec n x
@@ -113,11 +144,26 @@ instance CoArbitrary OrdB where
 -- OrdC
 
 newtype OrdC = OrdC{ unOrdC :: Integer }
-  deriving ( Eq, Ord
-#ifndef NO_NEWTYPE_DERIVING
-           , Num
-#endif
-           )
+  deriving ( Eq, Ord )
+
+liftOrdC
+    :: (Integer -> Integer)
+    -> OrdC -> OrdC
+liftOrdC f (OrdC x) = OrdC (f x)
+
+liftOrdC2
+    :: (Integer -> Integer -> Integer)
+    -> OrdC -> OrdC -> OrdC
+liftOrdC2 f (OrdC x) (OrdC y) = OrdC (f x y)
+
+instance Num OrdC where
+    (+)         = liftOrdC2 (+)
+    (*)         = liftOrdC2 (*)
+    (-)         = liftOrdC2 (-)
+    negate      = liftOrdC negate
+    abs         = liftOrdC abs
+    signum      = liftOrdC signum
+    fromInteger = OrdC . fromInteger
 
 instance Show OrdC where
   showsPrec n (OrdC x) = showsPrec n x

--- a/changelog
+++ b/changelog
@@ -4,8 +4,8 @@ QuickCheck HEAD
 	  argument
 	* Export 'Fun' type, 'apply', 'Function(..)' and 'functionMap' from
 	  'Test.QuickCheck'
-	* 'Test.QuickCheck.Function' and 'Test.QuickCheck.Poly' are now Safe
-	  modules
+	* 'Test.QuickCheck.Function', 'Test.QuickCheck.Poly', and
+	  'Test.QuickCheck.Monadic' are now Safe modules.
 
 QuickCheck 2.9.2 (released 2016-09-15)
 	* Fix a bug where some properties were only being tested once

--- a/changelog
+++ b/changelog
@@ -2,6 +2,15 @@ QuickCheck HEAD
 	* 'apply2', 'apply3' and 'Fn2', 'Fn3' added to
 	  Test.QuickCheck.Function for testing functions of more than one
 	  argument
+	* Export 'Fun' type, 'apply', 'Function(..)' and 'functionMap' from
+	  'Test.QuickCheck'
+	* 'Test.QuickCheck.Function' and 'Test.QuickCheck.Poly' are now Safe
+	  modules
+
+QuickCheck 2.9.2 (released 2016-09-15)
+	* Fix a bug where some properties were only being tested once
+	* Make shrinking of floating-point values less aggressive
+	* Add function chooseAny :: Random a => Gen a
 
 QuickCheck 2.9.1 (released 2016-07-11)
 	* 'again' was only used in forAllShrink, not forAll


### PR DESCRIPTION
- Export `Fun` type, `apply`, `Function(..)`, and `functionMap` from `Test.QuickCheck`
    - I often find I need just `Fun` and `apply` when writing test-suites. It could be very convenient if they are re-exported from `Test.QuickCheck`.
    - I intentionally didn't re-export `Fun` constructor
   -  For this I made `Test.QuickCheck.Function` and `Test.QuickCheck.Poly` *Safe*
- Also added documentation to 'Fun' and 'apply', so `Test.QuickCheck` haddock have something about them.
    - Added a type to 'Fn', for some reason I was getting `(t -> t) -> Fun t t` with GHC7.10.3 (in GHC-8.0 it seems to be fixed)
    - You can see this issue in old haddocks: http://hackage.haskell.org/package/QuickCheck-2.8.2/docs/Test-QuickCheck-Function.html#v:Fn 