### PR TITLE
Add a `chooseAny` Gen combinator

### DIFF
--- a/Test/QuickCheck/Gen.hs
+++ b/Test/QuickCheck/Gen.hs
@@ -11,6 +11,7 @@ module Test.QuickCheck.Gen where
 import System.Random
   ( Random
   , StdGen
+  , random
   , randomR
   , split
   , newStdGen
@@ -89,6 +90,10 @@ scale f g = sized (\n -> resize (f n) g)
 -- | Generates a random element in the given inclusive range.
 choose :: Random a => (a,a) -> Gen a
 choose rng = MkGen (\r _ -> let (x,_) = randomR rng r in x)
+
+-- | Generates a random element over the natural range of `a`.
+chooseAny :: Random a => Gen a
+chooseAny = MkGen (\r _ -> let (x,_) = random r in x)
 
 -- | Run a generator. The size passed to the generator is always 30;
 -- if you want another size then you should explicitly use 'resize'.


### PR DESCRIPTION
I often find myself needing to generate a random value over the entire natural range of an instance of `Random a`. Additionally, some instances of `Random` ignore the range argument of `randomR` and using the `choose` combinator doesn't make sense for these types, e.g. Data.UUID. This pull request adds a `chooseAny` combinator defined as

```haskell
chooseAny :: Random a => Gen a
``` 