### PR TITLE
Add more Arbitrary1 instances

### DIFF
--- a/Test/QuickCheck/Arbitrary.hs
+++ b/Test/QuickCheck/Arbitrary.hs
@@ -437,9 +437,7 @@ instance Arbitrary a => Arbitrary [a] where
 #ifndef NO_NONEMPTY
 instance Arbitrary1 NonEmpty where
   liftArbitrary arb = liftM2 (:|) arb (liftArbitrary arb)
-  liftShrink shr (x :| xs) =
-      [ x' :| xs | x' <- shr x ] ++
-      [ x :| xs' | xs' <- liftShrink shr xs ]
+  liftShrink shr (x :| xs) = mapMaybe nonEmpty . liftShrink shr $ x : xs
 
 instance Arbitrary a => Arbitrary (NonEmpty a) where
   arbitrary = arbitrary1


### PR DESCRIPTION
I left out tuples and monoid/semigroup (and some other) wrappers.

Also changed the `NonEmpty` shrink a bit, now it's better (no filtering).