### PR TITLE
Make `Monadic` functions not ignore the `a`s returned; use `()` instead

### DIFF
--- a/Test/QuickCheck/Monadic.hs
+++ b/Test/QuickCheck/Monadic.hs
@@ -208,10 +208,10 @@ monitor f = MkPropertyM (\k -> (f `liftM`) `fmap` (k ()))
 
 -- run functions
 
-monadic :: Monad m => (m Property -> Property) -> PropertyM m a -> Property
+monadic :: Monad m => (m Property -> Property) -> PropertyM m () -> Property
 monadic runner m = property (fmap runner (monadic' m))
 
-monadic' :: Monad m => PropertyM m a -> Gen (m Property)
+monadic' :: Monad m => PropertyM m () -> Gen (m Property)
 monadic' (MkPropertyM m) = m (const (return (return (property True))))
 
 -- | Runs the property monad for 'IO'-computations.
@@ -228,7 +228,7 @@ monadic' (MkPropertyM m) = m (const (return (return (property True))))
 -- >>> quickCheck prop_cat
 -- +++ OK, passed 100 tests.
 --
-monadicIO :: PropertyM IO a -> Property
+monadicIO :: PropertyM IO () -> Property
 monadicIO = monadic ioProperty
 
 #ifndef NO_ST_MONAD
@@ -247,7 +247,7 @@ monadicIO = monadic ioProperty
 -- >>> quickCheck prop_sortST
 -- +++ OK, passed 100 tests.
 --
-monadicST :: (forall s. PropertyM (ST s) a) -> Property
+monadicST :: (forall s. PropertyM (ST s) ()) -> Property
 monadicST m = property (runSTGen (monadic' m))
 
 runSTGen :: (forall s. Gen (ST s a)) -> Gen a

--- a/changelog
+++ b/changelog
@@ -6,6 +6,8 @@ QuickCheck HEAD
 	  'Test.QuickCheck'
 	* 'Test.QuickCheck.Function', 'Test.QuickCheck.Poly', and
 	  'Test.QuickCheck.Monadic' are now Safe modules.
+	* 'Test.QuickCheck.Monadic' functions no longer ignore returned
+	  `a`s, and use `()` instead.
 
 QuickCheck 2.9.2 (released 2016-09-15)
 	* Fix a bug where some properties were only being tested once


### PR DESCRIPTION
Fixes #134