### PR TITLE
Parallel generators / implementation matching

### DIFF
--- a/Test/QuickCheck.hs
+++ b/Test/QuickCheck.hs
@@ -122,6 +122,7 @@ module Test.QuickCheck
   , infiniteList
     -- ** Running a generator
   , generate
+  , replayer
     -- ** Generator debugging
   , sample
   , sample'

--- a/Test/QuickCheck.hs
+++ b/Test/QuickCheck.hs
@@ -116,6 +116,8 @@ module Test.QuickCheck
   , infiniteListOf
   , shuffle
   , sublistOf
+  , parallel
+  , (=!=)
     -- ** Generators which use Arbitrary
   , vector
   , orderedList

--- a/Test/QuickCheck/Gen.hs
+++ b/Test/QuickCheck/Gen.hs
@@ -102,6 +102,13 @@ generate (MkGen g) =
   do r <- newQCGen
      return (g r 30)
 
+-- | create a reproduceable generating environment
+replayer :: IO (Gen a -> a)
+replayer = do
+    r <- newQCGen
+    let repeater (MkGen g) = g r 30
+    return $ repeater
+
 -- | Generates some example values.
 sample' :: Gen a -> IO [a]
 sample' g =

--- a/Test/QuickCheck/Gen.hs
+++ b/Test/QuickCheck/Gen.hs
@@ -102,12 +102,21 @@ generate (MkGen g) =
   do r <- newQCGen
      return (g r 30)
 
--- | create a reproduceable generating environment
+-- | a reproduceable generate
 replayer :: IO (Gen a -> a)
 replayer = do
     r <- newQCGen
     let repeater (MkGen g) = g r 30
     return $ repeater
+
+-- | evaluate 2 generators with the same seed
+parallel :: Gen a -> Gen a -> Gen (a,a)
+parallel (MkGen x) (MkGen y) = MkGen $ \g n -> 
+    (x g n, y g n)
+
+-- | test generator equality, useful for implementation crosschecking
+(=!=) :: Eq a =>  Gen a -> Gen a -> Gen Bool
+a =!= b = fmap (\(x,y) -> x == y) $ parallel a b
 
 -- | Generates some example values.
 sample' :: Gen a -> IO [a]


### PR DESCRIPTION
I am testing 2 implementations for the same API one against the other one. Without (=!=)  I need some more boilerplate interleaved in the generating code.

```
test2Algo :: (Arbitrary a, Eq a) => Algo c a -> Algo d a -> Gen Bool
test2Algo x y = do
    (n :: Int) <- arbitrary
    (q,r,ts) <- (\f -> foldM f (newQueue x,newQueue y,[]) [0..n-1]) $ 
        \(q,r,ts) _ -> do
            xs <- listOf1 arbitrary
            k <- choose (0, length xs - 1) 
            let t x q = unloadn x k <$> elements 
                        [meld x (create x xs) q, flip (load x) xs q]
            (q',es) <- t x q
            (r',es') <- t y r
            return (q', r' , (es == es') : ts)
    return $ unload x q == unload y r && all id ts

test :: Gen Bool
test = test2Algo (naive :: Algo [] Int) efficient
```

With (=!=) I can just generate the ([a],[[a]]) and match them after so the testing function stay cleaner

```
genAlgo :: Arbitrary a => Algo c a -> Gen ([a], [[a]])
genAlgo x = do
    (n :: Int) <- arbitrary
    (q,ts) <- (\f -> foldM f (newQueue x,[]) [0..n-1]) $ 
        \(q,ts) _ -> do
            xs <- listOf1 arbitrary
            k <- choose (0, length xs - 1) 
            let t x q = unloadn x k <$> elements 
                        [meld x (create x xs) q, flip (load x) xs q]
            (q',es) <- t x q
            return (q', es : ts)
    return $ (unload x q, ts)

test :: Gen Bool
test = genAlgo (naive :: Algo [] Int)  =!= genAlgo efficient
```

The full code of the example is [here](https://gist.github.com/paolino/793ca314b5ff0876f99bec59fc091fae)


