### PR TITLE
Fixing LICENSE to be clearly a BSD-3-Clause

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 Copyright (c) 2000-2016, Koen Claessen
 Copyright (c) 2006-2008, Björn Bringert
 Copyright (c) 2009-2016, Nick Smallbone
-All rights reserved.
+https://opensource.org/licenses/BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
As you have selected the BSD-3_Clauses on Github I understand that is your purpose but writting in there "All rights reserved" at the same time is quite confusing.