### PR TITLE
Add genSize :: Gen Int

### DIFF
--- a/Test/QuickCheck.hs
+++ b/Test/QuickCheck.hs
@@ -106,6 +106,7 @@ module Test.QuickCheck
   , elements
   , growingElements
   , sized
+  , genSize
   , resize
   , scale
   , suchThat

--- a/Test/QuickCheck/Gen.hs
+++ b/Test/QuickCheck/Gen.hs
@@ -73,8 +73,34 @@ variant :: Integral n => n -> Gen a -> Gen a
 variant k (MkGen g) = MkGen (\r n -> g (variantQCGen k r) n)
 
 -- | Used to construct generators that depend on the size parameter.
+--
+-- For example, 'listOf', which uses the size parameter as an upper bound on
+-- length of lists it generates, can be defined like this:
+--
+-- > listOf :: Gen a -> Gen [a]
+-- > listOf gen = sized $ \n ->
+-- >   do k <- choose (0,n)
+-- >      vectorOf k gen
+--
+-- You can also do this using 'genSize'.
 sized :: (Int -> Gen a) -> Gen a
 sized f = MkGen (\r n -> let MkGen m = f n in m r n)
+
+-- | Generates the size parameter. Used to construct generators that depend on
+-- the size parameter.
+--
+-- For example, 'listOf', which uses the size parameter as an upper bound on
+-- length of lists it generates, can be defined like this:
+--
+-- > listOf :: Gen a -> Gen [a]
+-- > listOf gen = do
+-- >   n <- genSize
+-- >   k <- choose (0,n)
+-- >   vectorOf k gen
+--
+-- You can also do this using 'sized'.
+genSize :: Gen Int
+genSize = sized pure
 
 -- | Overrides the size parameter. Returns a generator which uses
 -- the given size instead of the runtime-size parameter.


### PR DESCRIPTION
This is a trivial little definition, but it helps write slightly nicer-looking generators.

As the docs in this PR demonstrate, one can rewrite

```haskell
listOf gen = sized $ \n -> do
  k <- choose (0, n)
  vectorOf k gen
```

as

```haskell
listOf gen = do
  n <- genSize
  k <- choose (0, n)
  vectorOf k gen
```

The latter style makes more sense to me, and I think it's easier to teach, so it'd be nice to have it in the library :)