### PR TITLE
Don't use {-# OVERLAPPING #-} pragmas on GHC < 7.10

### DIFF
--- a/Test/QuickCheck/Arbitrary.hs
+++ b/Test/QuickCheck/Arbitrary.hs
@@ -5,8 +5,11 @@
 {-# LANGUAGE DefaultSignatures, FlexibleContexts, TypeOperators #-}
 {-# LANGUAGE FlexibleInstances, KindSignatures, ScopedTypeVariables #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-#if __GLASGOW_HASKELL__ < 710
+#if __GLASGOW_HASKELL__ >= 710
+#define OVERLAPPING_ {-# OVERLAPPING #-}
+#else
 {-# LANGUAGE OverlappingInstances  #-}
+#define OVERLAPPING_
 #endif
 #endif
 #ifndef NO_POLYKINDS
@@ -376,10 +379,10 @@ instance GSubtermsIncl f a => GSubtermsIncl (M1 i c f) a where
   gSubtermsIncl (M1 x) = gSubtermsIncl x
 
 -- This is the important case: We've found a term of the same type.
-instance {-# OVERLAPPING #-} GSubtermsIncl (K1 i a) a where
+instance OVERLAPPING_ GSubtermsIncl (K1 i a) a where
   gSubtermsIncl (K1 x) = [x]
 
-instance {-# OVERLAPPING #-} GSubtermsIncl (K1 i a) b where
+instance OVERLAPPING_ GSubtermsIncl (K1 i a) b where
   gSubtermsIncl (K1 _) = []
 
 #endif


### PR DESCRIPTION
A minor thing: when you build the current version of `QuickCheck` on GHC < 7.10, it emits warnings. Example [here](https://travis-ci.org/sol/doctest/jobs/191673800#L806):

```
Test/QuickCheck/Arbitrary.hs:317:10: Warning: Unrecognised pragma

Test/QuickCheck/Arbitrary.hs:320:10: Warning: Unrecognised pragma
```

That's because GHC didn't support the `{-# OVERLAPPING #-}` pragma until GHC 7.10 (before then, it just used the `-XOverlappingInstances` extension. To avoid this, I used CPP to make `OVERLAPPING_` expand to `{-# OVERLAPPING #-}` on recent GHCs, but expand to nothing on older GHCs. This is the same trick that [`aeson` uses.](https://github.com/bos/aeson/blob/d470ac61874b4dc80b88a44a0c2d967430a8d5ce/include/overlapping-compat.h)