### PR TITLE
Add missing Function Word instance

### DIFF
--- a/Test/QuickCheck/Function.hs
+++ b/Test/QuickCheck/Function.hs
@@ -264,6 +264,9 @@ instance Function Integer where
 instance Function Int where
   function = functionIntegral
 
+instance Function Word where
+  function = functionIntegral
+
 instance Function Char where
   function = functionMap ord chr
 


### PR DESCRIPTION
There are instances of `Function` for `Word8/16/32/64`, but not for `Word` itself.