### PR TITLE
Remove light flag; migrate instances to quickcheck-instances

### DIFF
--- a/QuickCheck.cabal
+++ b/QuickCheck.cabal
@@ -1,5 +1,5 @@
 Name: QuickCheck
-Version: 2.9.2
+Version: 2.10
 Cabal-Version: >= 1.8
 Build-type: Simple
 License: BSD3
@@ -61,15 +61,8 @@ flag templateHaskell
   Description: Build Test.QuickCheck.All, which uses Template Haskell.
   Default: True
 
-flag light
-  Description:
-    Build with as few dependencies as possible.
-    Some instances will be missing, but build time will be reduced.
-    Can be useful on e.g. Travis.
-  Default: False
-
 library
-  Build-depends: base >=4.3 && <5, random, containers, array
+  Build-depends: base >=4.3 && <5, random, containers
 
   -- Modules that are always built.
   Exposed-Modules:
@@ -121,29 +114,8 @@ library
   else
     cpp-options: -DNO_TF_RANDOM
 
-  if impl(ghc) && (impl(ghc >= 7.8) || !flag(light))
-    -- 'Data.Proxy' is available in base only since GHC 7.8 / base-4.7
-    if impl(ghc < 7.8)
-      build-depends: tagged>=0.8.5
-  else
-      cpp-options: -DNO_PROXY
-
   if !impl(ghc >= 7.6)
       cpp-options: -DNO_POLYKINDS
-
-  if impl(ghc) && (impl(ghc >= 7.10) || !flag(light))
-    if impl(ghc < 7.10)
-      -- `Numeric.Natural` is available in base only since GHC 7.10 / base 4.8
-      build-depends: nats>=1
-  else
-      cpp-options: -DNO_NATURALS
-
-  if impl(ghc) && (impl(ghc >= 8.0) || !flag(light))
-    -- 'Data.List.NonEmpty' is available in base only since GHC 8.0 / base 4.9
-    if impl(ghc < 8.0)
-      build-depends: semigroups >=0.9
-  else
-      cpp-options: -DNO_NONEMPTY
 
   -- Switch off most optional features on non-GHC systems.
   if !impl(ghc)

--- a/Test/QuickCheck/Arbitrary.hs
+++ b/Test/QuickCheck/Arbitrary.hs
@@ -159,18 +159,6 @@ import Data.Functor.Identity
 import Data.Functor.Constant
 import Data.Functor.Compose
 import Data.Functor.Product
-
-#ifdef MIN_VERSION_transformers
-#if MIN_VERSION_transformers(0,4,0)
-#define TRANSFORMERS_SUM
-#endif
-#else
-#define TRANSFORMERS_SUM
-#endif
-
-#ifdef TRANSFORMERS_SUM
-import Data.Functor.Sum
-#endif
 #endif
 
 --------------------------------------------------------------------------
@@ -811,16 +799,6 @@ instance (Arbitrary1 f, Arbitrary1 g) => Arbitrary1 (Product f g) where
 instance (Arbitrary1 f, Arbitrary1 g, Arbitrary a) => Arbitrary (Product f g a) where
   arbitrary = arbitrary1
   shrink = shrink1
-
-#ifdef TRANSFORMERS_SUM
-instance (Arbitrary1 f, Arbitrary1 g) => Arbitrary1 (Sum f g) where
-  liftArbitrary arb = oneof [fmap InL (liftArbitrary arb), fmap InR (liftArbitrary arb)]
-  liftShrink shr (InL f) = map InL (liftShrink shr f)
-  liftShrink shr (InR g) = map InR (liftShrink shr g)
-instance (Arbitrary1 f, Arbitrary1 g, Arbitrary a) => Arbitrary (Sum f g a) where
-  arbitrary = arbitrary1
-  shrink = shrink1
-#endif
 
 instance (Arbitrary1 f, Arbitrary1 g) => Arbitrary1 (Compose f g) where
   liftArbitrary = fmap Compose . liftArbitrary . liftArbitrary

--- a/Test/QuickCheck/Arbitrary.hs
+++ b/Test/QuickCheck/Arbitrary.hs
@@ -110,14 +110,6 @@ import Data.Fixed
   )
 #endif
 
-#ifndef NO_NATURALS
-import Numeric.Natural
-#endif
-
-#ifndef NO_PROXY
-import Data.Proxy (Proxy (..))
-#endif
-
 import Data.Ratio
   ( Ratio
   , (%)
@@ -132,11 +124,6 @@ import Data.List
   ( sort
   , nub
   )
-
-#ifndef NO_NONEMPTY
-import Data.List.NonEmpty (NonEmpty (..), nonEmpty)
-import Data.Maybe (mapMaybe)
-#endif
 
 import Data.Version (Version (..))
 
@@ -166,8 +153,6 @@ import qualified Data.IntMap as IntMap
 import qualified Data.Sequence as Sequence
 
 import qualified Data.Monoid as Monoid
-import Data.Array.IArray
-import Data.Array.Unboxed
 
 #ifndef NO_TRANSFORMERS
 import Data.Functor.Identity
@@ -451,16 +436,6 @@ instance Arbitrary a => Arbitrary [a] where
   arbitrary = arbitrary1
   shrink = shrink1
 
-#ifndef NO_NONEMPTY
-instance Arbitrary1 NonEmpty where
-  liftArbitrary arb = liftM2 (:|) arb (liftArbitrary arb)
-  liftShrink shr (x :| xs) = mapMaybe nonEmpty . liftShrink shr $ x : xs
-
-instance Arbitrary a => Arbitrary (NonEmpty a) where
-  arbitrary = arbitrary1
-  shrink = shrink1
-#endif
-
 -- | Shrink a list of values given a shrinking function for individual values.
 shrinkList :: (a -> [a]) -> [a] -> [[a]]
 shrinkList shr xs = concat [ removes k n xs | k <- takeWhile (>0) (iterate (`div`2) n) ]
@@ -619,22 +594,6 @@ instance ( Arbitrary a, Arbitrary b, Arbitrary c, Arbitrary d, Arbitrary e
 instance Arbitrary Integer where
   arbitrary = arbitrarySizedIntegral
   shrink    = shrinkIntegral
-
-#ifndef NO_NATURALS
-instance Arbitrary Natural where
-  arbitrary = arbitrarySizedNatural
-  shrink    = shrinkIntegral
-#endif
-
-#ifndef NO_PROXY
-instance Arbitrary1 Proxy where
-  liftArbitrary _ = pure Proxy
-  liftShrink _ _ = []
-
-instance Arbitrary (Proxy a) where
-  arbitrary = pure Proxy
-  shrink _  = []
-#endif
 
 instance Arbitrary Int where
   arbitrary = arbitrarySizedIntegral
@@ -961,29 +920,7 @@ instance Arbitrary ExitCode where
   shrink (ExitFailure x) = ExitSuccess : [ ExitFailure x' | x' <- shrink x ]
   shrink _        = []
 
-instance (Num i, Ix i, Arbitrary i, Arbitrary a) => Arbitrary (Array i a) where
-  arbitrary = liftM2 makeArray arbitrary arbitrary
-  shrink = shrinkArray
 
-instance (Ix i, CoArbitrary i, CoArbitrary a) => CoArbitrary (Array i a) where
-  coarbitrary arr = coarbitrary (bounds arr, elems arr)
-
-instance (Num i, Ix i, IArray UArray a, Arbitrary i, Arbitrary a) => Arbitrary (UArray i a) where
-  arbitrary = liftM2 makeArray arbitrary arbitrary
-  shrink = shrinkArray
-
-instance (Ix i, IArray UArray a, CoArbitrary i, CoArbitrary a) => CoArbitrary (UArray i a) where
-  coarbitrary arr = coarbitrary (bounds arr, elems arr)
-
-shrinkArray :: (Num i, Ix i, IArray arr a, Arbitrary i, Arbitrary a) => arr i a -> [arr i a]
-shrinkArray arr =
-  [ makeArray lo xs | xs <- shrink (elems arr) ] ++
-  [ makeArray lo' (elems arr) | lo' <- shrink lo ]
-  where
-    (lo, _) = bounds arr
-
-makeArray :: (Num i, Ix i, IArray arr a) => i -> [a] -> arr i a
-makeArray lo xs = listArray (lo, lo + fromIntegral (length xs - 1)) xs
 
 -- ** Helper functions for implementing arbitrary
 
@@ -1249,11 +1186,6 @@ instance CoArbitrary a => CoArbitrary [a] where
   coarbitrary []     = variant 0
   coarbitrary (x:xs) = variant 1 . coarbitrary (x,xs)
 
-#ifndef NO_NONEMPTY
-instance CoArbitrary a => CoArbitrary (NonEmpty a) where
-  coarbitrary (x :| xs) = coarbitrary (x, xs)
-#endif
-
 instance (Integral a, CoArbitrary a) => CoArbitrary (Ratio a) where
   coarbitrary r = coarbitrary (numerator r,denominator r)
 
@@ -1299,16 +1231,6 @@ instance (CoArbitrary a, CoArbitrary b, CoArbitrary c, CoArbitrary d, CoArbitrar
 
 instance CoArbitrary Integer where
   coarbitrary = coarbitraryIntegral
-
-#ifndef NO_NATURALS
-instance CoArbitrary Natural where
-  coarbitrary = coarbitraryIntegral
-#endif
-
-#ifndef NO_PROXY
-instance CoArbitrary (Proxy a) where
-  coarbitrary _ = id
-#endif
 
 instance CoArbitrary Int where
   coarbitrary = coarbitraryIntegral

--- a/Test/QuickCheck/Function.hs
+++ b/Test/QuickCheck/Function.hs
@@ -78,18 +78,6 @@ import Data.Foldable(toList)
 import Data.Fixed
 #endif
 
-#ifndef NO_NATURALS
-import Numeric.Natural
-#endif
-
-#ifndef NO_PROXY
-import Data.Proxy (Proxy (..))
-#endif
-
-#ifndef NO_NONEMPTY
-import Data.List.NonEmpty(NonEmpty(..))
-#endif
-
 #ifndef NO_GENERICS
 import GHC.Generics hiding (C)
 #endif
@@ -289,14 +277,6 @@ instance Function Ordering where
       h (Left True)  = EQ
       h (Right _)    = GT
 
-#ifndef NO_NONEMPTY
-instance Function a => Function (NonEmpty a) where
-  function = functionMap g h
-   where
-     g (x :| xs) = (x,   xs)
-     h (x,   xs) =  x :| xs
-#endif
-
 instance (Integral a, Function a) => Function (Ratio a) where
   function = functionMap g h
    where
@@ -328,16 +308,6 @@ instance Function a => Function (IntMap.IntMap a) where
 
 instance Function a => Function (Sequence.Seq a) where
   function = functionMap toList Sequence.fromList
-
-#ifndef NO_PROXY
-instance Function (Proxy a) where
-  function = functionMap (const ()) (const Proxy)
-#endif
-
-#ifndef NO_NATURALS
-instance Function Natural where
-  function = functionIntegral
-#endif
 
 instance Function Int8 where
   function = functionBoundedEnum

--- a/Test/QuickCheck/Modifiers.hs
+++ b/Test/QuickCheck/Modifiers.hs
@@ -71,7 +71,7 @@ import Test.QuickCheck.Arbitrary
 import Data.List
   ( sort
   )
-import Data.Array.IArray(Ix)
+import Data.Ix (Ix)
 
 --------------------------------------------------------------------------
 -- | @Blind x@: as x, but x does not have to be in the 'Show' class.

--- a/changelog
+++ b/changelog
@@ -10,6 +10,7 @@ QuickCheck HEAD
 	  `a`s, and use `()` instead.
 	* Add `maxShrinks` parameter to `Args`. Number of shrinks to try
 	  before giving up shrinking.
+	* Move instances from `nats`, `semigroups` to `quickcheck-instances`
 
 QuickCheck 2.9.2 (released 2016-09-15)
 	* Fix a bug where some properties were only being tested once


### PR DESCRIPTION
Related to #158. See https://github.com/phadej/qc-instances/pull/2 for corresponding PR in `quickcheck-instances`.

cc @RyanGlScott 