### PR TITLE
Exported data constructor `Fun(Fun)`

### DIFF
--- a/Test/QuickCheck.hs
+++ b/Test/QuickCheck.hs
@@ -158,7 +158,7 @@ module Test.QuickCheck
   , PrintableString(..)
 
     -- ** Functions
-  , Fun
+  , Fun (..)
   , applyFun
   , applyFun2
   , applyFun3


### PR DESCRIPTION
Data constructor `Fun(Fun)` is not exported by `QuickCheck.hs`. This PR fix this issue.