### PR TITLE
Make (<*>) split only once

### DIFF
--- a/Test/QuickCheck/Gen.hs
+++ b/Test/QuickCheck/Gen.hs
@@ -48,7 +48,7 @@ instance Functor Gen where
 
 instance Applicative Gen where
   pure  = return
-  (<*>) = ap
+  gf <*> gx = gf >>= \f -> fmap f gx
 
 instance Monad Gen where
   return x =


### PR DESCRIPTION
`ap` calls `(>>=)` twice, and the third seed is discarded by `return`:

    ap mf mx = do f <- mf ; x <- mx ; return (f x)

Does this count as a breaking change? Does QuickCheck make stability guarantees that allow storing test cases as seeds?

