### PR TITLE
Fix comment in MkGen

### DIFF
--- a/Test/QuickCheck/Gen.hs
+++ b/Test/QuickCheck/Gen.hs
@@ -33,7 +33,7 @@ import Test.QuickCheck.Random
 
 -- | A generator for values of type @a@.
 newtype Gen a = MkGen{
-  unGen :: QCGen -> Int -> a -- ^ Run the generator on a particular seed.
+  unGen :: QCGen -> Int -> a -- ^ Run the generator with a particular size parameter.
                              -- If you just want to get a random value out, consider using 'generate'.
   }
 


### PR DESCRIPTION
From looking at how the the parameter is used, it is obviously the size, not a seed.