### PR TITLE
Coarbitrary exists, even without generics

### DIFF
--- a/Test/QuickCheck.hs
+++ b/Test/QuickCheck.hs
@@ -172,8 +172,8 @@ module Test.QuickCheck
   , functionBoundedEnum
 
     -- * The 'CoArbitrary' typeclass: generation of functions the old-fashioned way
-#ifndef NO_GENERICS
   , CoArbitrary(..)
+#ifndef NO_GENERICS
   , genericCoarbitrary
 #endif
   , variant


### PR DESCRIPTION
@nick8325 it would be very great to have a `2.11.5` release with this. 