### PR TITLE
Add MonadFail instance

### DIFF
--- a/Test/QuickCheck/Gen.hs
+++ b/Test/QuickCheck/Gen.hs
@@ -25,6 +25,8 @@ import Control.Monad
   , filterM
   )
 
+import Control.Monad.Fail
+
 import Control.Monad.Fix
   ( MonadFix(..) )
 
@@ -68,6 +70,11 @@ instance Monad Gen where
           let MkGen m' = k (m r1 n)
           in m' r2 n
     )
+  
+  fail = Control.Monad.Fail.fail
+
+instance Control.Monad.Fail.MonadFail Gen where
+  fail = error 
 
 instance MonadFix Gen where
   mfix f =


### PR DESCRIPTION
This instance is necessary in GHC 8.6 for do-notation `fail` desugaring to work