### PR TITLE
Explicitly derive instance Typeable Args

### DIFF
--- a/QuickCheck.cabal
+++ b/QuickCheck.cabal
@@ -1,5 +1,5 @@
 Name: QuickCheck
-Version: 2.12.6.1
+Version: 2.12.7
 Cabal-Version: >= 1.8
 Build-type: Simple
 License: BSD3

--- a/Test/QuickCheck/Test.hs
+++ b/Test/QuickCheck/Test.hs
@@ -1,6 +1,9 @@
 {-# OPTIONS_HADDOCK hide #-}
 -- | The main test loop.
 {-# LANGUAGE CPP #-}
+#ifndef NO_TYPEABLE
+{-# LANGUAGE DeriveDataTypeable #-}
+#endif
 #ifndef NO_SAFE_HASKELL
 {-# LANGUAGE Trustworthy #-}
 #endif
@@ -51,6 +54,10 @@ import Data.Either(lefts, rights)
 import Control.Monad
 import Data.Bits
 
+#ifndef NO_TYPEABLE
+import Data.Typeable (Typeable)
+#endif
+
 --------------------------------------------------------------------------
 -- quickCheck
 
@@ -79,7 +86,11 @@ data Args
     -- ^ Maximum number of shrinks to before giving up. Setting this to zero
     --   turns shrinking off.
   }
- deriving ( Show, Read )
+ deriving ( Show, Read
+#ifndef NO_TYPEABLE
+  , Typeable
+#endif
+  )
 
 -- | Result represents the test result
 data Result

--- a/changelog
+++ b/changelog
@@ -1,3 +1,7 @@
+QuickCheck 2.12.7 (unreleased)
+	* Explicitly derive instance Typeable Args (for compatibility with
+	  older versions of GHC)
+
 QuickCheck 2.12.6 (released 2018-10-02)
 	* Make arbitrarySizedBoundedIntegral handle huge sizes correctly.
 	* Add changelog for QuickCheck 2.12.5 :)


### PR DESCRIPTION
(for compatibility with older versions of GHC)