### PR TITLE
Add HasCallStack where error can occur

### DIFF
--- a/QuickCheck.cabal
+++ b/QuickCheck.cabal
@@ -62,7 +62,7 @@ flag templateHaskell
   Default: True
 
 library
-  Build-depends: base >=4.3 && <5, random, containers, erf >= 2
+  Build-depends: base >=4.3 && <5, call-stack, random, containers, erf >= 2
 
   -- Modules that are always built.
   Exposed-Modules:

--- a/Test/QuickCheck/Gen.hs
+++ b/Test/QuickCheck/Gen.hs
@@ -35,6 +35,7 @@ import Test.QuickCheck.Random
 import Data.List
 import Data.Ord
 import Data.Maybe
+import GHC.Stack (HasCallStack)
 
 --------------------------------------------------------------------------
 -- ** Generator type
@@ -197,7 +198,7 @@ frequency xs0 = choose (1, tot) >>= (`pick` xs0)
   pick _ _  = error "QuickCheck.pick used with empty list"
 
 -- | Generates one of the given values. The input list must be non-empty.
-elements :: [a] -> Gen a
+elements :: HasCallStack => [a] -> Gen a
 elements [] = error "QuickCheck.elements used with empty list"
 elements xs = (xs !!) `fmap` choose (0, length xs - 1)
 

--- a/Test/QuickCheck/Gen.hs
+++ b/Test/QuickCheck/Gen.hs
@@ -32,10 +32,10 @@ import Control.Applicative
   ( Applicative(..) )
 
 import Test.QuickCheck.Random
+import Data.CallStack (HasCallStack)
 import Data.List
 import Data.Ord
 import Data.Maybe
-import GHC.Stack (HasCallStack)
 
 --------------------------------------------------------------------------
 -- ** Generator type


### PR DESCRIPTION
When this fails due to an empty list there's no stack trace pointing to the bad "elements" call.