### PR TITLE
Add maxFailPercent argument.

### DIFF
--- a/Test/QuickCheck/All.hs
+++ b/Test/QuickCheck/All.hs
@@ -82,7 +82,7 @@ expName n = if isVar n then VarE n else ConE n
 
 -- See section 2.4 of the Haskell 2010 Language Report, plus support for "[]"
 isVar :: Name -> Bool
-isVar = let isVar' (c:_) = not (isUpper c || c `elem` ":[")
+isVar = let isVar' (c:_) = not (isUpper c || c `elem` (":[" :: String))
             isVar' _     = True
         in isVar' . nameBase
 

--- a/Test/QuickCheck/State.hs
+++ b/Test/QuickCheck/State.hs
@@ -18,6 +18,8 @@ data State
     -- ^ the current terminal
   , maxSuccessTests           :: Int
     -- ^ maximum number of successful tests needed
+  , maxFailedPercent          :: Int
+    -- ^ maximum percent of failed tests allowed
   , maxDiscardedRatio         :: Int
     -- ^ maximum number of discarded tests per successful test
   , coverageConfidence        :: Maybe Confidence
@@ -31,6 +33,8 @@ data State
     -- dynamic
   , numSuccessTests           :: !Int
     -- ^ the current number of tests that have succeeded
+  , numFailedTests            :: Int
+    -- ^ the current number of failed tests
   , numDiscardedTests         :: !Int
     -- ^ the current number of discarded tests
   , numRecentlyDiscardedTests :: !Int


### PR DESCRIPTION
I've been reading about statistical testing in the Cleanroom software engineering [literature](https://ksiresearchorg.ipage.com/seke/seke17paper/seke17paper_91.pdf) recently. Overall their approach is close to what QuickCheck does (especially paired with state machine testing), but they differ in that they see the results of testing as a measure of quality (e.g. the program is 90% reliable with 95% confidence) not a proof of correctness (i.e. success or failure).

Inspired by this, I've added a `maxFailPercent` argument to `Args` which works like this:

```haskell
> quickCheckWith stdArgs { maxFailPercent = 10 } $ forAll (choose (0, 10)) $ \i -> i `elem` [0..9]
*** Failed! Falsifiable (after 16 tests):  
10
*** Failed! Falsifiable (after 36 tests):  
10
*** Failed! Falsifiable (after 48 tests):  
10
*** Failed! Falsifiable (after 52 tests):  
10
*** Failed! Falsifiable (after 69 tests):  
10
*** Failed! Falsifiable (after 74 tests):  
10
*** Failed! Falsifiable (after 80 tests):  
10
*** Failed! Falsifiable (after 82 tests):  
10
+++ OK, passed 92 tests; 8 failed (8%).

--

> quickCheckWith stdArgs { maxFailPercent = 10 } $ forAll (choose (0, 10)) $ \i -> i `elem` [0..9]
*** Failed! Falsifiable (after 5 tests):  
10
*** Failed! Falsifiable (after 7 tests):  
10
*** Failed! Falsifiable (after 9 tests):  
10
*** Failed! Falsifiable (after 9 tests):  
10
*** Failed! Falsifiable (after 46 tests):  
10
*** Failed! Falsifiable (after 47 tests):  
10
*** Failed! Falsifiable (after 49 tests):  
10
*** Failed! Falsifiable (after 49 tests):  
10
*** Failed! Falsifiable (after 58 tests):  
10
*** Failed! Falsifiable (after 58 tests):  
10
*** Failed! Passed only 47 tests; 10 failed (10%) tests.
```

The default `maxFailPercent` is 0 and retains the old behaviour.

Thoughts?