### PR TITLE
replace "Falsifiable" in error message into some better word

### DIFF
--- a/Test/QuickCheck.hs
+++ b/Test/QuickCheck.hs
@@ -146,7 +146,7 @@ module Test.QuickCheck
     -- >>>     prop (Fun _ f) = f "monkey" == f "banana" || f "banana" == f "elephant"
     -- >>> :}
     -- >>> quickCheck prop
-    -- *** Failed! Falsism (after 3 tests and 134 shrinks):
+    -- *** Failed! Falsified (after 3 tests and 134 shrinks):
     -- {"elephant"->1, "monkey"->1, _->0}
     --
     -- To generate random values of type @'Fun' a b@,

--- a/Test/QuickCheck.hs
+++ b/Test/QuickCheck.hs
@@ -146,7 +146,7 @@ module Test.QuickCheck
     -- >>>     prop (Fun _ f) = f "monkey" == f "banana" || f "banana" == f "elephant"
     -- >>> :}
     -- >>> quickCheck prop
-    -- *** Failed! Falsifiable (after 3 tests and 134 shrinks):
+    -- *** Failed! Falsism (after 3 tests and 134 shrinks):
     -- {"elephant"->1, "monkey"->1, _->0}
     --
     -- To generate random values of type @'Fun' a b@,

--- a/Test/QuickCheck/Function.hs
+++ b/Test/QuickCheck/Function.hs
@@ -27,7 +27,7 @@
 -- >>>     prop (Fun _ f) = f "monkey" == f "banana" || f "banana" == f "elephant"
 -- >>> :}
 -- >>> quickCheck prop
--- *** Failed! Falsism (after 3 tests and 134 shrinks):
+-- *** Failed! Falsified (after 3 tests and 134 shrinks):
 -- {"elephant"->1, "monkey"->1, _->0}
 --
 -- To generate random values of type @'Fun' a b@,

--- a/Test/QuickCheck/Function.hs
+++ b/Test/QuickCheck/Function.hs
@@ -27,7 +27,7 @@
 -- >>>     prop (Fun _ f) = f "monkey" == f "banana" || f "banana" == f "elephant"
 -- >>> :}
 -- >>> quickCheck prop
--- *** Failed! Falsifiable (after 3 tests and 134 shrinks):
+-- *** Failed! Falsism (after 3 tests and 134 shrinks):
 -- {"elephant"->1, "monkey"->1, _->0}
 --
 -- To generate random values of type @'Fun' a b@,

--- a/Test/QuickCheck/Modifiers.hs
+++ b/Test/QuickCheck/Modifiers.hs
@@ -186,7 +186,7 @@ instance Arbitrary a => Arbitrary (NonEmptyList a) where
 -- the remaining (infinite) part can contain anything:
 --
 -- >>> quickCheck prop_take_10
--- *** Failed! Falsifiable (after 1 test and 14 shrinks):
+-- *** Failed! Falsism (after 1 test and 14 shrinks):
 -- "bbbbbbbbbb" ++ ...
 data InfiniteList a =
   InfiniteList {

--- a/Test/QuickCheck/Modifiers.hs
+++ b/Test/QuickCheck/Modifiers.hs
@@ -186,7 +186,7 @@ instance Arbitrary a => Arbitrary (NonEmptyList a) where
 -- the remaining (infinite) part can contain anything:
 --
 -- >>> quickCheck prop_take_10
--- *** Failed! Falsism (after 1 test and 14 shrinks):
+-- *** Failed! Falsified (after 1 test and 14 shrinks):
 -- "bbbbbbbbbb" ++ ...
 data InfiniteList a =
   InfiniteList {

--- a/Test/QuickCheck/Property.hs
+++ b/Test/QuickCheck/Property.hs
@@ -305,7 +305,7 @@ succeeded, failed, rejected :: Result
 
 liftBool :: Bool -> Result
 liftBool True = succeeded
-liftBool False = failed { reason = "Falsifiable" }
+liftBool False = failed { reason = "Falsism" }
 
 mapResult :: Testable prop => (Result -> Result) -> prop -> Property
 mapResult f = mapRoseResult (protectResults . fmap f)

--- a/Test/QuickCheck/Property.hs
+++ b/Test/QuickCheck/Property.hs
@@ -305,7 +305,7 @@ succeeded, failed, rejected :: Result
 
 liftBool :: Bool -> Result
 liftBool True = succeeded
-liftBool False = failed { reason = "Falsism" }
+liftBool False = failed { reason = "Falsified" }
 
 mapResult :: Testable prop => (Result -> Result) -> prop -> Property
 mapResult f = mapRoseResult (protectResults . fmap f)


### PR DESCRIPTION
I think use "Falsifiable" here is not very appropriate, since it emphasize the **inherent possibility** that a statement can be proven false. In our case, the proposition is already shown to be False, and we have found an obvious evidence about that, so I think "Falsism" could be better here.


> Falsifiability or refutability of a statement, hypothesis, or theory is the inherent possibility that it can be proven false. A statement is called falsifiable if it is possible to conceive of an observation or an argument which negates the statement in question.

> A falsism is a claim that is clearly and self-evidently wrong. A falsism is usually used merely as a reminder or as a rhetorical or literary device. An example is "pigs can fly." It is the opposite of truism.