### PR TITLE
Declare required API versions of `deepseq`

### DIFF
--- a/QuickCheck.cabal
+++ b/QuickCheck.cabal
@@ -84,7 +84,7 @@ library
   -- GHC-specific modules.
   if impl(ghc)
     Exposed-Modules: Test.QuickCheck.Function
-    Build-depends: transformers >= 0.3, deepseq
+    Build-depends: transformers >= 0.3, deepseq >= 1.3.0.0 && < 1.5
   else
     cpp-options: -DNO_TRANSFORMERS -DNO_DEEPSEQ
 


### PR DESCRIPTION
QuickCheck needs the `NFData (->)` instance which is only available in deepseq 1.3.* and 1.4.*
(and it won't be available in a future deepseq-1.5 which won't be released for any time soon)

```
Test/QuickCheck/Property.hs:707:10:
    Could not deduce (NFData (Result -> [(String, String)]))
      arising from a use of `deepseq'
    from the context (Testable prop)
      bound by the type signature for
                 coverTable :: Testable prop =>
                               String -> [(String, Double)] -> prop -> Property
      at Test/QuickCheck/Property.hs:(706,1)-(711,48)
```

I've also already fixed up the metadata in the affected releases accordingly:

 - https://hackage.haskell.org/package/QuickCheck-2.12/revisions/
 - https://hackage.haskell.org/package/QuickCheck-2.12.1/revisions/
 - https://hackage.haskell.org/package/QuickCheck-2.12.2/revisions/
 - https://hackage.haskell.org/package/QuickCheck-2.12.3/revisions/
 - https://hackage.haskell.org/package/QuickCheck-2.12.4/revisions/
 - https://hackage.haskell.org/package/QuickCheck-2.12.5/revisions/
 - https://hackage.haskell.org/package/QuickCheck-2.12.6.1/revisions/
