### PR TITLE
Add bounds for random

### DIFF
--- a/QuickCheck.cabal
+++ b/QuickCheck.cabal
@@ -63,7 +63,7 @@ flag templateHaskell
   Default: True
 
 library
-  Build-depends: base >=4.3 && <5, random, containers
+  Build-depends: base >=4.3 && <5, random >=1.0.1.0 && <1.2, containers
 
   -- Modules that are always built.
   Exposed-Modules:


### PR DESCRIPTION
- Lower bound: prior random-1.0.1.0 it wasn't `Trustworthy`, so compiling QuickCheck fails
- Upper bound: `random-1.2` (or whatever next major) will change things, though it's not clear when it will be released. Better to have bounds in place, so we won't need to make revisions later.