### PR TITLE
Fix non-valid unicode issue

### DIFF
--- a/Test/QuickCheck/Arbitrary.hs
+++ b/Test/QuickCheck/Arbitrary.hs
@@ -1055,9 +1055,12 @@ arbitrarySizedBoundedIntegral =
 -- | Generates any Unicode character (but not a surrogate)
 arbitraryUnicodeChar :: Gen Char
 arbitraryUnicodeChar =
-  arbitraryBoundedEnum `suchThat` (not . isSurrogate)
+  arbitraryBoundedEnum `suchThat` isValidUnicode
   where
-    isSurrogate c = generalCategory c == Surrogate
+    isValidUnicode c = case generalCategory c of
+      Surrogate -> False
+      NotAssigned -> False
+      _ -> True
 
 -- | Generates a random ASCII character (0-127).
 arbitraryASCIIChar :: Gen Char


### PR DESCRIPTION
By standard, Unicode has sixty-six noncharacters, which can be incorrectly
interpreted by different applications. To prevent possible troubles,
characters with NotAssigned property shouldn't be generated.