### PR TITLE
Improve Gen instances

### DIFF
--- a/Test/QuickCheck/Gen.hs
+++ b/Test/QuickCheck/Gen.hs
@@ -56,12 +56,16 @@ instance Functor Gen where
     MkGen (\r n -> f (h r n))
 
 instance Applicative Gen where
-  pure  = return
-  gf <*> gx = gf >>= \f -> fmap f gx
+  pure x =
+    MkGen (\_ _ -> x)
+  (<*>) = ap
+
+  -- We don't need to split the seed for these.
+  _ *> m = m
+  m <* _ = m
 
 instance Monad Gen where
-  return x =
-    MkGen (\_ _ -> x)
+  return = pure
 
   MkGen m >>= k =
     MkGen (\r n ->
@@ -70,6 +74,8 @@ instance Monad Gen where
           let MkGen m' = k (m r1 n)
           in m' r2 n
     )
+
+  (>>) = (*>)
 
 instance MonadFix Gen where
   mfix f =


### PR DESCRIPTION
* Write custom `(*>)`, `(<*)`, and `(>>)` implementations for `Gen`;
  these can avoid splitting the seed. They're also essentially useless,
  but they could show up if someone uses `Applicative`-generic
  operations of some sort.

* Move the implementation from `return` to `pure` for `Gen`, rendering
  the `return` implementation "canonical".