### PR TITLE
Make some generators more efficient by using splitmix primitives.

### DIFF
--- a/QuickCheck.cabal
+++ b/QuickCheck.cabal
@@ -120,7 +120,7 @@ library
 
   -- Use splitmix on newer GHCs.
   if impl(ghc >= 7.0)
-    Build-depends: splitmix >= 0.0.2
+    Build-depends: splitmix >= 0.0.4
   else
     cpp-options: -DNO_SPLITMIX
 


### PR DESCRIPTION
SplitMix generates uniform Word64, by using this knowledge
we can generate numbers more efficiently.

`bitmaskWithRejection64' n` behaves as `choose (0, n)`,
but is more efficient.

In a small tests-suite generating list of characters,
the speedup is noticeable (max-size is 1000):

    CharSet
      fromList . toList:     OK (23.73s)
        +++ OK, passed 100000 tests.
      member:                OK (22.50s)
        +++ OK, passed 100000 tests.
      union:                 OK (49.02s)
        +++ OK, passed 100000 tests.
      union: left identity:  OK (22.99s)
        +++ OK, passed 100000 tests.
      union: right identity: OK (22.81s)
        +++ OK, passed 100000 tests.
      union: commutativity:  OK (48.55s)
        +++ OK, passed 100000 tests.
      union: associativity:  OK (76.98s)
        +++ OK, passed 100000 tests.

speeds up to:

    CharSet
      fromList . toList:     OK (17.49s)
        +++ OK, passed 100000 tests.
      member:                OK (16.31s)
        +++ OK, passed 100000 tests.
      union:                 OK (36.63s)
        +++ OK, passed 100000 tests.
      union: left identity:  OK (17.06s)
        +++ OK, passed 100000 tests.
      union: right identity: OK (16.79s)
        +++ OK, passed 100000 tests.
      union: commutativity:  OK (36.23s)
        +++ OK, passed 100000 tests.
      union: associativity:  OK (58.36s)
        +++ OK, passed 100000 tests.