### PR TITLE
Export RecursivelyShrink & GSubterms

### DIFF
--- a/Test/QuickCheck/Arbitrary.hs
+++ b/Test/QuickCheck/Arbitrary.hs
@@ -55,6 +55,8 @@ module Test.QuickCheck.Arbitrary
   , arbitraryPrintableChar -- :: Gen Char
   -- ** Helper functions for implementing shrink
 #ifndef NO_GENERICS
+  , RecursivelyShrink
+  , GSubterms
   , genericShrink      -- :: (Generic a, Arbitrary a, RecursivelyShrink (Rep a), GSubterms (Rep a) a) => a -> [a]
   , subterms           -- :: (Generic a, Arbitrary a, GSubterms (Rep a) a) => a -> [a]
   , recursivelyShrink  -- :: (Generic a, RecursivelyShrink (Rep a)) => a -> [a]


### PR DESCRIPTION
I am using `genericShrink` but require `RecursivelyShrink` and `GSubterms` to be exported for my type signatures.

Would you be open to exporting these types?