### PR TITLE
WIP: Add random flag to drop 'random' dependency

### DIFF
--- a/QuickCheck.cabal
+++ b/QuickCheck.cabal
@@ -61,15 +61,27 @@ source-repository this
 flag templateHaskell
   Description: Build Test.QuickCheck.All, which uses Template Haskell.
   Default: True
+  Manual: True
+
+flag random
+  Description: Build Test.QuickCheck.All, which uses Template Haskell.
+  Default: False
+  Manual: True
+
 
 library
-  Build-depends: base >=4.3 && <5, random >=1.0.0.3 && <1.2, containers
+  Build-depends: base >=4.3 && <5, containers
 
-  -- random is explicitly Trustworthy since 1.0.1.0
-  -- similar constraint for containers
-  -- Note: QuickCheck is Safe only with GHC >= 7.4 (see below)
-  if impl(ghc >= 7.2)
-    Build-depends: random >=1.0.1.0
+  if flag(random)
+    Build-depends: random >=1.0.0.3 && <1.2
+    -- random is explicitly Trustworthy since 1.0.1.0
+    -- similar constraint for containers
+    -- Note: QuickCheck is Safe only with GHC >= 7.4 (see below)
+    if impl(ghc >= 7.2)
+      Build-depends: random >=1.0.1.0
+  else
+    cpp-options: -DNO_RANDOM
+
   if impl(ghc >= 7.4)
     Build-depends: containers >=0.4.2.1
 

--- a/Test/QuickCheck.hs
+++ b/Test/QuickCheck.hs
@@ -94,12 +94,16 @@ module Test.QuickCheck
     -- * The 'Gen' monad: combinators for building random generators
   , Gen
     -- ** Generator combinators
+#ifndef NO_RANDOM
   , choose
+#endif
   , chooseInt
   , chooseInteger
   , chooseBoundedIntegral
   , chooseEnum
+#ifndef NO_RANDOM
   , chooseAny
+#endif
   , oneof
   , frequency
   , elements
@@ -130,7 +134,9 @@ module Test.QuickCheck
   , arbitrarySizedFractional
   , arbitrarySizedBoundedIntegral
   , arbitraryBoundedIntegral
+#ifndef NO_RANDOM
   , arbitraryBoundedRandom
+#endif
   , arbitraryBoundedEnum
   , arbitraryUnicodeChar
   , arbitraryASCIIChar

--- a/Test/QuickCheck/Arbitrary.hs
+++ b/Test/QuickCheck/Arbitrary.hs
@@ -47,7 +47,9 @@ module Test.QuickCheck.Arbitrary
   , arbitraryBoundedIntegral      -- :: (Bounded a, Integral a) => Gen a
   , arbitrarySizedBoundedIntegral -- :: (Bounded a, Integral a) => Gen a
   , arbitrarySizedFractional      -- :: Fractional a => Gen a
+#ifndef NO_RANDOM
   , arbitraryBoundedRandom        -- :: (Bounded a, Random a) => Gen a
+#endif
   , arbitraryBoundedEnum          -- :: (Bounded a, Enum a) => Gen a
   -- ** Generators for various kinds of character
   , arbitraryUnicodeChar   -- :: Gen Char
@@ -88,10 +90,13 @@ module Test.QuickCheck.Arbitrary
 
 import Control.Applicative
 import Data.Foldable(toList)
-import System.Random(Random)
 import Test.QuickCheck.Gen
 import Test.QuickCheck.Random
 import Test.QuickCheck.Gen.Unsafe
+
+#ifdef NO_SPLITMIX
+import System.Random(Random)
+#endif
 
 {-
 import Data.Generics
@@ -1018,10 +1023,12 @@ withBounds k = k minBound maxBound
 arbitraryBoundedIntegral :: (Bounded a, Integral a) => Gen a
 arbitraryBoundedIntegral = chooseBoundedIntegral (minBound, maxBound)
 
+#ifndef NO_RANDOM
 -- | Generates an element of a bounded type. The element is
 -- chosen from the entire range of the type.
 arbitraryBoundedRandom :: (Bounded a, Random a) => Gen a
 arbitraryBoundedRandom = choose (minBound,maxBound)
+#endif
 
 -- | Generates an element of a bounded enumeration.
 arbitraryBoundedEnum :: (Bounded a, Enum a) => Gen a

--- a/Test/QuickCheck/Test.hs
+++ b/Test/QuickCheck/Test.hs
@@ -20,7 +20,6 @@ import Test.QuickCheck.State hiding (labels, classes, tables, requiredCoverage)
 import qualified Test.QuickCheck.State as S
 import Test.QuickCheck.Exception
 import Test.QuickCheck.Random
-import System.Random(split)
 #if defined(MIN_VERSION_containers)
 #if MIN_VERSION_containers(0,5,0)
 import qualified Data.Map.Strict as Map
@@ -407,7 +406,7 @@ runATest st f =
                             , failingClasses  = Set.fromList (P.classes res)
                             }
  where
-  (rnd1,rnd2) = split (randomSeed st)
+  (rnd1,rnd2) = splitQCGen (randomSeed st)
 
 failureSummary :: State -> P.Result -> String
 failureSummary st res = fst (failureSummaryAndReason st res)


### PR DESCRIPTION
There is a `random` refactoring work going on, and it's API will change drastically. See https://github.com/idontgetoutmuch/random/
cc @lehins

This PR is a work in progress to see how much one can do just with `splitmix`: Turns out quite a lot. We "only" lose
- `choose`
- `chooseAny`
- `arbitraryBoundedRandom`

The question is that when new `random` will comes out, what configuration options `QuickCheck` should support (and how) out of:
- old random, for hugs and older GHCs
- splitmix
- new random

It looks like that the default random generator of new `random` will be `splitmix`. Therefore, we could have two flags:

```
flag splitmix
  description: Use splitmix as random number generator

flag random
  description: Add `random` utilities. This flag should be set to `True`, if `splitmix` is False.
```

Making three configurations:

```
splitmix = True,  random = True    -- default setting
splitmix = True,  random = False
splitmix = False, random = True
```

As all this is complicated, this is why I open this discussion now.
I think we could even make this change before new `random` version is released,
then adopting to new `random` (and `splitmix` which would drop `random` dependency due https://github.com/phadej/splitmix/issues/34)
more straightforward.

Adding the new flags won't even be a breaking change, as with
their default setting won't change the public API.

---

One to do item is to write `nextInteger` for `splitmix` (which would select uniformly from the range of two `Integer`s). I'll do that soon.

Some other small changes:
- Making `templateHaskell` flag `manual: True`, currently it's automatic. I have indeed been bitten by it being toggled off automatically.
- Adding explicit `splitQCGen`