### PR TITLE
Introduce 'assertWith' for better debugging on monadic assertions

### DIFF
--- a/Test/QuickCheck/Monadic.hs
+++ b/Test/QuickCheck/Monadic.hs
@@ -56,6 +56,7 @@ module Test.QuickCheck.Monadic (
   -- * Monadic specification combinators
   , run
   , assert
+  , assertWith
   , pre
   , wp
   , pick
@@ -149,6 +150,28 @@ stop p = MkPropertyM (\_k -> return (return (property p)))
 assert :: Monad m => Bool -> PropertyM m ()
 assert True  = return ()
 assert False = fail "Assertion failed"
+
+-- | Like 'assert' but allows caller to specify an explicit message to show on failure.
+--
+-- __Example:__
+--
+-- @
+-- do
+--   assertWith True  "My first predicate."
+--   assertWith False "My other predicate."
+--   ...
+-- @
+--
+-- @
+-- Assertion failed (after 2 tests):
+--     Passed: My first predicate
+--     Failed: My other predicate
+-- @
+assertWith :: Monad m => Bool -> String -> PropertyM m ()
+assertWith condition msg = do
+    let prefix = if condition then "Passed: " else "Failed: "
+    monitor $ counterexample $ prefix <> msg
+    assert condition
 
 -- should think about strictness/exceptions here
 -- | Tests preconditions. Unlike 'assert' this does not cause the


### PR DESCRIPTION
The current 'assert' is a bit rough in the sense that it doesn't give any feedback other than something failed. In particular, if a test makes several assertions it can be tricky to figure out which one failed and for which reason. 'assertWith' makes it possible to specify an error message that is shown only on failure (piggy back on 'counterexample') but, clearly shows the result of the assertion for an easier debugging output.

![Screenshot from 2020-05-04 14-40-18](https://user-images.githubusercontent.com/5680256/80966803-811f7000-8e15-11ea-8b8a-29a09e7f60f9.png)

Cheers :wave: 
