### PR TITLE
Generate Rational numbers with smaller denominators

### DIFF
--- a/src/Test/QuickCheck/Arbitrary.hs
+++ b/src/Test/QuickCheck/Arbitrary.hs
@@ -998,13 +998,10 @@ inBounds fi g = fmap fi (g `suchThat` (\x -> toInteger x == toInteger (fi x)))
 -- and its maximum absolute value depends on the size parameter.
 arbitrarySizedFractional :: Fractional a => Gen a
 arbitrarySizedFractional =
-  sized $ \n ->
-    let n' = toInteger n in
-      do b <- chooseInteger (1, precision)
-         a <- chooseInteger ((-n') * b, n' * b)
-         return (fromRational (a % b))
- where
-  precision = 9999999999999 :: Integer
+  sized $ \n -> do
+    numer <- chooseInt (-n, n)
+    denom <- chooseInt (1, max 1 n)
+    pure $ fromIntegral numer / fromIntegral denom
 
 -- Useful for getting at minBound and maxBound without having to
 -- fiddle around with asTypeOf.


### PR DESCRIPTION
Closes #295, making maximal denominator dependent on `size` instead of being fixed to `9999999999999`. 

```haskell
> sample (arbitrarySizedFractional :: Gen Rational)
0 % 1
(-1) % 1
3 % 4
4 % 3
(-1) % 1
8 % 5
1 % 1
(-3) % 2
4 % 7
(-2) % 3
(-1) % 1
```