### PR TITLE
Tweak Float and Double Arbitrary Instances.

### DIFF
--- a/src/Test/QuickCheck/Arbitrary.hs
+++ b/src/Test/QuickCheck/Arbitrary.hs
@@ -683,11 +683,55 @@ instance Arbitrary Char where
                 )
 
 instance Arbitrary Float where
-  arbitrary = arbitrarySizedFractional
+  arbitrary = oneof
+    -- generate 0..1 numbers with full precision
+    [ genFloat
+    -- generate integral numbers
+    , fromIntegral <$> (arbitrary :: Gen Int)
+    -- generate fractions with small denominators
+    , smallDenominators
+    -- uniform -size..size with with denominators ~ size
+    , uniform
+    -- and uniform -size..size with higher precision
+    , arbitrarySizedFractional
+    ]
+    where
+      smallDenominators = sized $ \n -> do
+        i <- chooseInt (0, n)
+        pure (fromRational (streamNth i rationalUniverse))
+
+      uniform = sized $ \n -> do
+        let n' = toInteger n
+        b <- chooseInteger (1, max 1 n')
+        a <- chooseInteger ((-n') * b, n' * b)
+        return (fromRational (a % b))
+
   shrink    = shrinkDecimal
 
 instance Arbitrary Double where
-  arbitrary = arbitrarySizedFractional
+  arbitrary = oneof
+    -- generate 0..1 numbers with full precision
+    [ genDouble
+    -- generate integral numbers
+    , fromIntegral <$> (arbitrary :: Gen Int)
+    -- generate fractions with small denominators
+    , smallDenominators
+    -- uniform -size..size with with denominators ~ size
+    , uniform
+    -- and uniform -size..size with higher precision
+    , arbitrarySizedFractional
+    ]
+    where
+      smallDenominators = sized $ \n -> do
+        i <- chooseInt (0, n)
+        pure (fromRational (streamNth i rationalUniverse))
+
+      uniform = sized $ \n -> do
+        let n' = toInteger n
+        b <- chooseInteger (1, max 1 n')
+        a <- chooseInteger ((-n') * b, n' * b)
+        return (fromRational (a % b))
+
   shrink    = shrinkDecimal
 
 instance Arbitrary CChar where
@@ -994,7 +1038,7 @@ arbitrarySizedNatural =
 inBounds :: Integral a => (Int -> a) -> Gen Int -> Gen a
 inBounds fi g = fmap fi (g `suchThat` (\x -> toInteger x == toInteger (fi x)))
 
--- | Generates a fractional number. The number can be positive or negative
+-- | Uniformly generates a fractional number. The number can be positive or negative
 -- and its maximum absolute value depends on the size parameter.
 arbitrarySizedFractional :: Fractional a => Gen a
 arbitrarySizedFractional =
@@ -1449,6 +1493,42 @@ orderedList = sort `fmap` arbitrary
 -- | Generates an infinite list.
 infiniteList :: Arbitrary a => Gen [a]
 infiniteList = infiniteListOf arbitrary
+
+
+--------------------------------------------------------------------------
+-- ** Rational helper
+
+infixr 5 :<
+data Stream a = !a :< Stream a
+
+streamNth :: Int -> Stream a -> a
+streamNth n (x :< xs) | n <= 0    = x
+                      | otherwise = streamNth (n - 1) xs
+
+-- We read into this stream only with ~size argument,
+-- so it's ok to have it as CAF.
+--
+rationalUniverse :: Stream Rational
+rationalUniverse = 0 :< 1 :< (-1) :< go leftSideStream
+  where
+    go (x :< xs) =
+      let nx = -x
+          rx = recip x
+          nrx = -rx
+      in nx `seq` rx `seq` nrx `seq` (x :< rx :< nx :< nrx :< go xs)
+
+-- All the rational numbers on the left side of the Calkin-Wilf tree,
+-- in breadth-first order.
+leftSideStream :: Stream Rational
+leftSideStream = (1 % 2) :< go leftSideStream
+  where
+    go (x :< xs) =
+        lChild `seq` rChild `seq`
+        (lChild :< rChild :< go xs)
+      where
+        nd = numerator x + denominator x
+        lChild = numerator x % nd
+        rChild = nd % denominator x
 
 --------------------------------------------------------------------------
 -- the end.

--- a/src/Test/QuickCheck/Gen.hs
+++ b/src/Test/QuickCheck/Gen.hs
@@ -36,7 +36,7 @@ import Data.List
 import Data.Ord
 import Data.Maybe
 #ifndef NO_SPLITMIX
-import System.Random.SplitMix(bitmaskWithRejection64', SMGen, nextInteger)
+import System.Random.SplitMix(bitmaskWithRejection64', nextInteger, nextDouble, nextFloat, SMGen)
 #endif
 import Data.Word
 import Data.Int
@@ -238,6 +238,23 @@ sample :: Show a => Gen a -> IO ()
 sample g =
   do cases <- sample' g
      mapM_ print cases
+
+--------------------------------------------------------------------------
+-- ** Floating point
+
+-- | Generate 'Double' in 0..1 range
+genDouble :: Gen Double
+
+-- | Generate 'Float' in 0..1 range
+genFloat :: Gen Float
+
+#ifndef NO_SPLITMIX
+genDouble = MkGen $ \(QCGen g) _ -> fst (nextDouble g)
+genFloat  = MkGen $ \(QCGen g) _ -> fst (nextFloat g)
+#else
+genDouble = choose (0,1)
+genFloat  = choose (0,1)
+#endif
 
 --------------------------------------------------------------------------
 -- ** Common generator combinators

--- a/tests/Generators.hs
+++ b/tests/Generators.hs
@@ -204,5 +204,17 @@ instance Arbitrary B1 where
 prop_B1 :: B1 -> Property
 prop_B1 (B1 n) = expectFailure $ n === n + 1
 
+-- Double properties:
+
+-- We occasionaly generate duplicates.
+prop_double_duplicate_list :: [Double] -> Property
+prop_double_duplicate_list xs = expectFailure $ nub xs === xs where
+  sorted = sort xs
+
+-- And enough numbers to show basic IEEE pit falls.
+prop_double_assoc :: Double -> Double -> Double -> Property
+prop_double_assoc x y z = expectFailure $ x + (y + z) === (x + y) + z
+
+
 return []
 main = do True <- $forAllProperties (quickCheckWithResult stdArgs { maxShrinks = 10000 }); return ()


### PR DESCRIPTION
Tries to address comments in https://github.com/nick8325/quickcheck/issues/295
and https://github.com/nick8325/quickcheck/pull/296

Doesn't change how arbitrarySizedFractional works.
Now it is only used for (Ratio a) instance.

Also two properties which should fail everytime:
the Double generator has a chance of generating same values,
and it also hits values which break addition associativity.

---

My take on #295 