### PR TITLE
Use splitmix-0.0.5's nextInteger, and support splitmix-0.1 (i.e. don't rely on RandomGen SMGen instance)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,82 +28,82 @@ matrix:
   include:
     - compiler: "ghc-7.0.4"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.0.4], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.2,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.2.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.2.2], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.2,ghc-7.2.2], sources: [hvr-ghc]}}
     - compiler: "ghc-7.4.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.4.2], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.2,ghc-7.4.2], sources: [hvr-ghc]}}
     - compiler: "ghc-7.6.1"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.6.1], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.2,ghc-7.6.1], sources: [hvr-ghc]}}
     - compiler: "ghc-7.6.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.6.2], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.2,ghc-7.6.2], sources: [hvr-ghc]}}
     - compiler: "ghc-7.6.3"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.6.3], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.2,ghc-7.6.3], sources: [hvr-ghc]}}
     - compiler: "ghc-7.8.1"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.8.1], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.2,ghc-7.8.1], sources: [hvr-ghc]}}
     - compiler: "ghc-7.8.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.8.2], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.2,ghc-7.8.2], sources: [hvr-ghc]}}
     - compiler: "ghc-7.8.3"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.8.3], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.2,ghc-7.8.3], sources: [hvr-ghc]}}
     - compiler: "ghc-7.8.4"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.8.4], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.2,ghc-7.8.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.10.1"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.10.1], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.2,ghc-7.10.1], sources: [hvr-ghc]}}
     - compiler: "ghc-7.10.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.10.2], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.2,ghc-7.10.2], sources: [hvr-ghc]}}
     - compiler: "ghc-7.10.3"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.10.3], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.2,ghc-7.10.3], sources: [hvr-ghc]}}
     - compiler: "ghc-8.0.1"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.0.1], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.2,ghc-8.0.1], sources: [hvr-ghc]}}
     - compiler: "ghc-8.0.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.0.2], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.2,ghc-8.0.2], sources: [hvr-ghc]}}
     - compiler: "ghc-8.2.1"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.1], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.2,ghc-8.2.1], sources: [hvr-ghc]}}
     - compiler: "ghc-8.2.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.2,ghc-8.2.2], sources: [hvr-ghc]}}
     - compiler: "ghc-8.4.1"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.2,ghc-8.4.1], sources: [hvr-ghc]}}
     - compiler: "ghc-8.4.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.2], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.2,ghc-8.4.2], sources: [hvr-ghc]}}
     - compiler: "ghc-8.4.3"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.3], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.2,ghc-8.4.3], sources: [hvr-ghc]}}
     - compiler: "ghc-8.4.4"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.4], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.2,ghc-8.4.4], sources: [hvr-ghc]}}
     - compiler: "ghc-8.6.1"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.6.1], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.2,ghc-8.6.1], sources: [hvr-ghc]}}
     - compiler: "ghc-8.6.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.6.2], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.2,ghc-8.6.2], sources: [hvr-ghc]}}
     - compiler: "ghc-8.6.3"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.6.3], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.2,ghc-8.6.3], sources: [hvr-ghc]}}
     - compiler: "ghc-8.6.4"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.6.4], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.2,ghc-8.6.4], sources: [hvr-ghc]}}
     - compiler: "ghc-head"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-head], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.2,ghc-head], sources: [hvr-ghc]}}
 
   allow_failures:
     - compiler: "ghc-head"

--- a/QuickCheck.cabal
+++ b/QuickCheck.cabal
@@ -120,7 +120,7 @@ library
 
   -- Use splitmix on newer GHCs.
   if impl(ghc >= 7.0)
-    Build-depends: splitmix >= 0.0.4
+    Build-depends: splitmix >= 0.0.5 && <0.2
   else
     cpp-options: -DNO_SPLITMIX
 

--- a/Test/QuickCheck/Gen.hs
+++ b/Test/QuickCheck/Gen.hs
@@ -36,7 +36,7 @@ import Data.List
 import Data.Ord
 import Data.Maybe
 #ifndef NO_SPLITMIX
-import System.Random.SplitMix(bitmaskWithRejection64', SMGen)
+import System.Random.SplitMix(bitmaskWithRejection64', SMGen, nextInteger)
 #endif
 import Data.Word
 import Data.Int
@@ -187,14 +187,7 @@ chooseInteger :: (Integer, Integer) -> Gen Integer
 #ifdef NO_SPLITMIX
 chooseInteger = choose
 #else
-chooseInteger (lo, hi)
-  | lo >= toInteger (minBound :: Int64) && lo <= toInteger (maxBound :: Int64) &&
-    hi >= toInteger (minBound :: Int64) && hi <= toInteger (maxBound :: Int64) =
-    fmap toInteger (chooseInt64 (fromInteger lo, fromInteger hi))
-  | lo >= toInteger (minBound :: Word64) && lo <= toInteger (maxBound :: Word64) &&
-    hi >= toInteger (minBound :: Word64) && hi <= toInteger (maxBound :: Word64) =
-    fmap toInteger (chooseWord64 (fromInteger lo, fromInteger hi))
-  | otherwise = choose (lo, hi)
+chooseInteger (lo, hi) = MkGen $ \(QCGen g) _ -> fst (nextInteger lo hi g)
 
 chooseWord64 :: (Word64, Word64) -> Gen Word64
 chooseWord64 (lo, hi)

--- a/Test/QuickCheck/Random.hs
+++ b/Test/QuickCheck/Random.hs
@@ -27,13 +27,26 @@ instance Read QCGen where
   readsPrec n xs = [(QCGen g, ys) | (g, ys) <- readsPrec n xs]
 
 instance RandomGen QCGen where
+#ifdef NO_SPLITMIX
   split (QCGen g) =
     case split g of
       (g1, g2) -> (QCGen g1, QCGen g2)
+
   genRange (QCGen g) = genRange g
   next (QCGen g) =
     case next g of
       (x, g') -> (x, QCGen g')
+#else
+  split (QCGen g) =
+    case splitSMGen g of
+      (g1, g2) -> (QCGen g1, QCGen g2)
+
+  genRange (QCGen g) = (minBound, maxBound)
+
+  next (QCGen g) =
+    case nextInt g of
+      (x, g') -> (x, QCGen g')
+#endif
 
 newQCGen :: IO QCGen
 #ifdef NO_SPLITMIX


### PR DESCRIPTION
splitmix-0.1 dropped dependency on random. But that's
a non-issue, as QuickCheck doesn't use any `random` instances
of `SMGen`, we only need to implement `RandomGen QCGen`
in terms of splitmix combinators

Related: https://github.com/phadej/splitmix/issues/34

EDIT: I made revisions to `QuickCheck-2.13 .. 2.14` to disallow `splitmix-0.1` (which doesn't have `RangomGen` instance anymore), e.g. https://hackage.haskell.org/package/QuickCheck-2.14/revisions/

EDIT2: Travis job https://travis-ci.org/github/nick8325/quickcheck/builds/692237337