### PR TITLE
Compatibility with new version of random

### DIFF
--- a/QuickCheck.cabal
+++ b/QuickCheck.cabal
@@ -1,5 +1,5 @@
 Name: QuickCheck
-Version: 2.14
+Version: 2.14.1
 Cabal-Version: >= 1.8
 Build-type: Simple
 License: BSD3
@@ -63,7 +63,7 @@ flag templateHaskell
   Default: True
 
 library
-  Build-depends: base >=4.3 && <5, random >=1.0.0.3 && <1.2, containers
+  Build-depends: base >=4.3 && <5, random >=1.0.0.3 && <1.3, containers
 
   -- random is explicitly Trustworthy since 1.0.1.0
   -- similar constraint for containers

--- a/Test/QuickCheck/Random.hs
+++ b/Test/QuickCheck/Random.hs
@@ -11,6 +11,9 @@ import System.Random
 import System.Random.SplitMix
 #endif
 import Data.Bits
+#if MIN_VERSION_random(1,2,0)
+import Data.Coerce
+#endif
 
 -- | The "standard" QuickCheck random number generator.
 -- A wrapper around either 'SMGen' on GHC, or 'StdGen'
@@ -30,10 +33,20 @@ instance RandomGen QCGen where
   split (QCGen g) =
     case split g of
       (g1, g2) -> (QCGen g1, QCGen g2)
+#if MIN_VERSION_random(1,2,0)
+  genWord8 (QCGen g) = coerce (genWord8 g)
+  genWord16 (QCGen g) = coerce (genWord16 g)
+  genWord32 (QCGen g) = coerce (genWord32 g)
+  genWord64 (QCGen g) = coerce (genWord64 g)
+  genWord32R r (QCGen g) = coerce (genWord32R r g)
+  genWord64R r (QCGen g) = coerce (genWord64R r g)
+  genShortByteString n (QCGen g) = coerce (genShortByteString n g)
+#else
   genRange (QCGen g) = genRange g
   next (QCGen g) =
     case next g of
       (x, g') -> (x, QCGen g')
+#endif
 
 newQCGen :: IO QCGen
 #ifdef NO_SPLITMIX

--- a/changelog
+++ b/changelog
@@ -1,3 +1,5 @@
+QuickCheck 2.14.1 (release 2020-X-X)
+	* Compatibility with new version of `random-1.2`
 QuickCheck 2.14 (release 2020-03-28)
 	* QuickCheck is now much faster at generating test data!
 	  As a result, many properties can now be tested a lot faster;


### PR DESCRIPTION
This PR implements compatibility with `random-1.2.0`, which was finally released today