### PR TITLE
Support GHC-9.0 (template-haskell-2.17) and allow `StarT`-kinded TVs

### DIFF
--- a/src/Test/QuickCheck/All.hs
+++ b/src/Test/QuickCheck/All.hs
@@ -99,11 +99,16 @@ infoType (VarI _ ty _ _) = ty
 
 deconstructType :: Error -> Type -> Q ([Name], Cxt, Type)
 deconstructType err (ForallT xs ctx ty) = do
-  let plain (PlainTV nm)          = return nm
-#if MIN_VERSION_template_haskell(2,8,0)
-      plain (KindedTV nm StarT)   = return nm
+#if MIN_VERSION_template_haskell(2,17,0)
+  let plain (PlainTV nm _)        = return nm
+      plain (KindedTV nm _ StarT) = return nm
 #else
+  let plain (PlainTV nm)          = return nm
+#  if MIN_VERSION_template_haskell(2,8,0)
+      plain (KindedTV nm StarT)   = return nm
+#  else
       plain (KindedTV nm StarK)   = return nm
+#  endif
 #endif
       plain _                     = err "Higher-kinded type variables in type"
   xs' <- traverse plain xs

--- a/src/Test/QuickCheck/All.hs
+++ b/src/Test/QuickCheck/All.hs
@@ -111,7 +111,7 @@ deconstructType err (ForallT xs ctx ty) = do
 #  endif
 #endif
       plain _                     = err "Higher-kinded type variables in type"
-  xs' <- traverse plain xs
+  xs' <- mapM plain xs
   return (xs', ctx, ty)
 deconstructType _ ty = return ([], [], ty)
 

--- a/src/Test/QuickCheck/All.hs
+++ b/src/Test/QuickCheck/All.hs
@@ -98,16 +98,16 @@ infoType (VarI _ ty _ _) = ty
 #endif
 
 deconstructType :: Error -> Type -> Q ([Name], Cxt, Type)
-deconstructType err ty0@(ForallT xs ctx ty) = do
-  let plain (PlainTV  _)       = True
+deconstructType err (ForallT xs ctx ty) = do
+  let plain (PlainTV nm)          = return nm
 #if MIN_VERSION_template_haskell(2,8,0)
-      plain (KindedTV _ StarT) = True
+      plain (KindedTV nm StarT)   = return nm
 #else
-      plain (KindedTV _ StarK) = True
+      plain (KindedTV nm StarK)   = return nm
 #endif
-      plain _                  = False
-  unless (all plain xs) $ err "Higher-kinded type variables in type"
-  return (map (\(PlainTV x) -> x) xs, ctx, ty)
+      plain _                     = err "Higher-kinded type variables in type"
+  xs' <- traverse plain xs
+  return (xs', ctx, ty)
 deconstructType _ ty = return ([], [], ty)
 
 monomorphiseType :: Error -> Type -> Type -> TypeQ


### PR DESCRIPTION
(1) Fix bad unipattern in lambda
(2) Update patterns for updated `TyVarBndr` from template-haskell-2.17.0

While opening this PR I noticed that #311 also addresses (2), however it addresses (1) differently and apparently incorrectly.

The uni-patterned lambda would previously incorrectly fail on `KindedTV nm StarT` and #311 unnecessarily reproduces this failure.

This patch is also shorter and clearer.