### PR TITLE
Implemented instances for Newline and NewlineMode

### DIFF
--- a/src/Test/QuickCheck/Arbitrary.hs
+++ b/src/Test/QuickCheck/Arbitrary.hs
@@ -138,7 +138,7 @@ import Data.List
 import Data.Version (Version (..))
 
 #if defined(MIN_VERSION_base)
-#if MIN_VERSION_base(4,7,0) || MIN_VERSION_base(4,4,0) && !defined(__NHC__) && !defined(__HUGS__)
+#if MIN_VERSION_base(4,7,0) || MIN_VERSION_base(4,2,0) && !defined(__NHC__) && !defined(__HUGS__)
 import System.IO
   ( Newline(..)
   , NewlineMode(..)
@@ -997,7 +997,7 @@ instance Arbitrary ExitCode where
   shrink _        = []
 
 #if defined(MIN_VERSION_base)
-#if MIN_VERSION_base(4,7,0) || MIN_VERSION_base(4,4,0) && !defined(__NHC__) && !defined(__HUGS__)
+#if MIN_VERSION_base(4,7,0) || MIN_VERSION_base(4,2,0) && !defined(__NHC__) && !defined(__HUGS__)
 instance Arbitrary Newline where
   arbitrary = elements [LF, CRLF]
 
@@ -1475,7 +1475,7 @@ instance CoArbitrary Version where
   coarbitrary (Version a b) = coarbitrary (a, b)
 
 #if defined(MIN_VERSION_base)
-#if MIN_VERSION_base(4,7,0) || MIN_VERSION_base(4,4,0) && !defined(__NHC__) && !defined(__HUGS__)
+#if MIN_VERSION_base(4,7,0) || MIN_VERSION_base(4,2,0) && !defined(__NHC__) && !defined(__HUGS__)
 instance CoArbitrary Newline where
   coarbitrary LF = variant 0
   coarbitrary CRLF = variant 1

--- a/src/Test/QuickCheck/Arbitrary.hs
+++ b/src/Test/QuickCheck/Arbitrary.hs
@@ -137,10 +137,14 @@ import Data.List
 
 import Data.Version (Version (..))
 
+#if defined(MIN_VERSION_base)
+#if MIN_VERSION_base(4,7,0) || MIN_VERSION_base(4,4,0) && !defined(__NHC__) && !defined(__HUGS__)
 import System.IO
   ( Newline(..)
   , NewlineMode(..)
   )
+#endif
+#endif
 
 import Control.Monad
   ( liftM
@@ -992,6 +996,8 @@ instance Arbitrary ExitCode where
   shrink (ExitFailure x) = ExitSuccess : [ ExitFailure x' | x' <- shrink x ]
   shrink _        = []
 
+#if defined(MIN_VERSION_base)
+#if MIN_VERSION_base(4,7,0) || MIN_VERSION_base(4,4,0) && !defined(__NHC__) && !defined(__HUGS__)
 instance Arbitrary Newline where
   arbitrary = elements [LF, CRLF]
 
@@ -1007,6 +1013,8 @@ instance Arbitrary NewlineMode where
   arbitrary = NewlineMode <$> arbitrary <*> arbitrary
 
   shrink (NewlineMode inNL outNL) = [NewlineMode inNL' outNL' | (inNL', outNL') <- shrink (inNL, outNL)]
+#endif
+#endif
 
 -- ** Helper functions for implementing arbitrary
 
@@ -1466,12 +1474,16 @@ instance CoArbitrary (f a) => CoArbitrary (Monoid.Alt f a) where
 instance CoArbitrary Version where
   coarbitrary (Version a b) = coarbitrary (a, b)
 
+#if defined(MIN_VERSION_base)
+#if MIN_VERSION_base(4,7,0) || MIN_VERSION_base(4,4,0) && !defined(__NHC__) && !defined(__HUGS__)
 instance CoArbitrary Newline where
   coarbitrary LF = variant 0
   coarbitrary CRLF = variant 1
 
 instance CoArbitrary NewlineMode where
   coarbitrary (NewlineMode inNL outNL) = coarbitrary inNL . coarbitrary outNL
+#endif
+#endif
 
 -- ** Helpers for implementing coarbitrary
 

--- a/src/Test/QuickCheck/Arbitrary.hs
+++ b/src/Test/QuickCheck/Arbitrary.hs
@@ -1006,7 +1006,7 @@ instance Arbitrary Newline where
 instance Arbitrary NewlineMode where
   arbitrary = NewlineMode <$> arbitrary <*> arbitrary
 
-  shrink (NewlineMode inNL outNL) = [NewlineMode inNL' outNL' | inNL' <- shrink inNL, outNL' <- shrink outNL]
+  shrink (NewlineMode inNL outNL) = [NewlineMode inNL' outNL' | (inNL', outNL') <- shrink (inNL, outNL)]
 
 -- ** Helper functions for implementing arbitrary
 

--- a/src/Test/QuickCheck/Function.hs
+++ b/src/Test/QuickCheck/Function.hs
@@ -82,10 +82,15 @@ import Data.Complex
 import Data.Foldable(toList)
 import Data.Functor.Identity
 import qualified Data.Monoid as Monoid
+
+#if defined(MIN_VERSION_base)
+#if MIN_VERSION_base(4,7,0) || MIN_VERSION_base(4,4,0) && !defined(__NHC__) && !defined(__HUGS__)
 import System.IO
   ( Newline(..)
   , NewlineMode(..)
   )
+#endif
+#endif
 
 #ifndef NO_FIXED
 import Data.Fixed
@@ -371,6 +376,8 @@ instance Function Word32 where
 instance Function Word64 where
   function = functionIntegral
 
+#if defined(MIN_VERSION_base)
+#if MIN_VERSION_base(4,7,0) || MIN_VERSION_base(4,4,0) && !defined(__NHC__) && !defined(__HUGS__)
 instance Function Newline where
   function = functionMap g h
     where
@@ -385,6 +392,8 @@ instance Function NewlineMode where
     where
       g (NewlineMode inNL outNL) = (inNL,outNL)
       h (inNL,outNL) = NewlineMode inNL outNL
+#endif
+#endif
 
 -- instances for Data.Monoid newtypes
 

--- a/src/Test/QuickCheck/Function.hs
+++ b/src/Test/QuickCheck/Function.hs
@@ -82,6 +82,10 @@ import Data.Complex
 import Data.Foldable(toList)
 import Data.Functor.Identity
 import qualified Data.Monoid as Monoid
+import System.IO
+  ( Newline(..)
+  , NewlineMode(..)
+  )
 
 #ifndef NO_FIXED
 import Data.Fixed
@@ -366,6 +370,21 @@ instance Function Word32 where
 
 instance Function Word64 where
   function = functionIntegral
+
+instance Function Newline where
+  function = functionMap g h
+    where
+      g LF = False
+      g CRLF = True
+
+      h False = LF
+      h True = CRLF
+
+instance Function NewlineMode where
+  function = functionMap g h
+    where
+      g (NewlineMode inNL outNL) = (inNL,outNL)
+      h (inNL,outNL) = NewlineMode inNL outNL
 
 -- instances for Data.Monoid newtypes
 

--- a/src/Test/QuickCheck/Function.hs
+++ b/src/Test/QuickCheck/Function.hs
@@ -84,7 +84,7 @@ import Data.Functor.Identity
 import qualified Data.Monoid as Monoid
 
 #if defined(MIN_VERSION_base)
-#if MIN_VERSION_base(4,7,0) || MIN_VERSION_base(4,4,0) && !defined(__NHC__) && !defined(__HUGS__)
+#if MIN_VERSION_base(4,7,0) || MIN_VERSION_base(4,2,0) && !defined(__NHC__) && !defined(__HUGS__)
 import System.IO
   ( Newline(..)
   , NewlineMode(..)
@@ -377,7 +377,7 @@ instance Function Word64 where
   function = functionIntegral
 
 #if defined(MIN_VERSION_base)
-#if MIN_VERSION_base(4,7,0) || MIN_VERSION_base(4,4,0) && !defined(__NHC__) && !defined(__HUGS__)
+#if MIN_VERSION_base(4,7,0) || MIN_VERSION_base(4,2,0) && !defined(__NHC__) && !defined(__HUGS__)
 instance Function Newline where
   function = functionMap g h
     where


### PR DESCRIPTION
These are similar to the instances for bools and a pair of bools *but* we shrink towards `LF` because, according to `Newline`'s [documentation in base](https://hackage.haskell.org/package/base-4.14.0.0/docs/System-IO.html#g:25), Haskell assumes `\n` in its programs, and `LF` means we don't need any translations.
`CRLF`, means we do need to translate, meaning it will normally be the more complex case.

By implementing `Arbitrary`, `CoArbitrary` and `Function` instances for both [`Newline`](https://hackage.haskell.org/package/base-4.14.0.0/docs/System-IO.html#t:Newline) and [`NewlineMode`](https://hackage.haskell.org/package/base-4.14.0.0/docs/System-IO.html#t:NewlineMode), this closes issue #322