### PR TITLE
Fix installation instructions in README

### DIFF
--- a/README
+++ b/README
@@ -1,8 +1,6 @@
 This is QuickCheck 2, a library for random testing of program properties.
 
-Install it in the usual way:
-
-$ cabal install
+Add `QuickCheck` to your package dependencies to use it in tests or REPL.
 
 The quickcheck-instances [1] companion package provides instances for types in
 Haskell Platform packages at the cost of additional dependencies.


### PR DESCRIPTION
The `cabal install` way suggested 10+ years ago before the advent of sandboxed projects.