### PR TITLE
Make templateHaskell flag manual

### DIFF
--- a/QuickCheck.cabal
+++ b/QuickCheck.cabal
@@ -62,10 +62,12 @@ source-repository this
 flag templateHaskell
   Description: Build Test.QuickCheck.All, which uses Template Haskell.
   Default: True
+  Manual: True
 
 flag old-random
   Description: Build against a pre-1.2.0 version of the random package.
   Default: False
+  Manual: False
 
 library
   Hs-source-dirs: src
@@ -114,7 +116,10 @@ library
 
   if impl(ghc) && flag(templateHaskell) && !impl(haste)
     Build-depends: template-haskell >= 2.4
-    Other-Extensions: TemplateHaskell
+    if impl(ghc >=8.0)
+      Other-Extensions: TemplateHaskellQuotes
+    else
+      Other-Extensions: TemplateHaskell
     Exposed-Modules: Test.QuickCheck.All
   else
     cpp-options: -DNO_TEMPLATE_HASKELL


### PR DESCRIPTION
So it isn't triggered by cabal-solver automatically.

This patch also makes use of TemplateHaskellQuotes extension on GHC-8.0+
https://downloads.haskell.org/ghc/latest/docs/html/users_guide/glasgow_exts.html?highlight=templatehaskellquotes#extension-TemplateHaskellQuotes

This extension allows to make some quotes, even
when GHC doesn't support TemplateHaskell (e.g. ghc-stage1).

This way template haskell functionality can be always compiled.

This way making `templateHaskell` flag manual doesn't hurt,
as its default `True` value shouldn't pose problems.