### PR TITLE
A way to timeout tests without failing.

### DIFF
--- a/src/Test/QuickCheck.hs
+++ b/src/Test/QuickCheck.hs
@@ -269,6 +269,7 @@ module Test.QuickCheck
   , noShrinking
   , withMaxSuccess
   , within
+  , rejectOnTimeout
   , once
   , again
   , mapSize

--- a/src/Test/QuickCheck/Property.hs
+++ b/src/Test/QuickCheck/Property.hs
@@ -778,7 +778,19 @@ True  ==> p = property p
 --
 -- Bad: @prop_foo a b c = ...; main = quickCheck (within 1000000 prop_foo)@
 within :: Testable prop => Int -> prop -> Property
-within n = mapRoseResult f
+within n = onTimeout
+   (failed { reason = "Timeout of " ++ show n ++ " microseconds exceeded." })
+   n
+
+-- | Like 'within', but instead of fail in case of a timeout it only rejects
+-- the test case. It can make sense to use this for algorithms with a good
+-- average complexity, but much longer worst-case runtime.
+rejectOnTimeout n = onTimeout
+   (rejected { reason = "Timeout of " ++ show n ++ " microseconds exceeded." })
+   n
+
+onTimeout :: Testable prop => Result -> Int -> prop -> Property
+onTimeout timeoutResult n = mapRoseResult f
   where
     f rose = ioRose $ do
       let m `orError` x = fmap (fromMaybe x) m
@@ -787,11 +799,11 @@ within n = mapRoseResult f
       res' <- timeout n (protectResult (return res)) `orError`
         timeoutResult
       return (MkRose res' (map f roses))
-
-    timeoutResult = failed { reason = "Timeout of " ++ show n ++ " microseconds exceeded." }
 #ifdef NO_TIMEOUT
     timeout _ = fmap Just
 #endif
+
+
 
 -- | Explicit universal quantification: uses an explicitly given
 -- test case generator.


### PR DESCRIPTION
Consider an algorithm with good average case complexity, but bad worst-case one. (QuickSort with its  _O_ (_n_ · log _n_) runtime on average but worst-case _O_ (_n_<sup>2</sup>) would be an example; in the actual application I'm working on right now, it's actually more like quadratic vs. exponential!)

So, if we QuickCheck this it'll usually work just fine and, well, _quickly_, even for long lists – but sometimes QuickCheck will generate a sorted or mostly-sorted one, which dramatically slows down the runtime. This means the test suite has a very nondeterministic runtime – in my case, the test in question usually does 500 runs in 0.1 seconds, but then sometimes it takes 10 seconds for just a single run, and gigabytes of memory. This is not all that bad while I'm working on my own machine, but for CI it does pose a problem when there are sporadic failures due to timeout or memory quota.

I don't really want to manually restrict the inputs to avoid triggering this behaviour in the first place (it's actually tricky to see what inputs are problematic, unlike in the QuickSort example).

What I can of course do is adding a timeout in QuickCheck itself. Currently, [within](https://hackage.haskell.org/package/QuickCheck-2.14.2/docs/Test-QuickCheck.html#v:within) is exported for that purpose – but again, it'll mean there will be sporadic _failures_ of the test suite, although the tested code doesn't have a bug but just follows expected behaviour of the algorithm.

The `rejectOnTimeout` I'm proposing does instead only _reject_ such a test case, so it is possible to ignore these very long-running instances without changing anything else about the test coverage.