### PR TITLE
Add StatefulGen instance for Gen

### DIFF
--- a/src/Test/QuickCheck.hs
+++ b/src/Test/QuickCheck.hs
@@ -93,6 +93,7 @@ module Test.QuickCheck
 
     -- * The 'Gen' monad: combinators for building random generators
   , Gen
+  , QC(..)
     -- ** Generator combinators
   , choose
   , chooseInt

--- a/src/Test/QuickCheck/Gen.hs
+++ b/src/Test/QuickCheck/Gen.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 #ifndef NO_ST_MONAD
 {-# LANGUAGE Rank2Types #-}
 #endif
@@ -42,7 +43,9 @@ import Data.Word
 import Data.Int
 import Data.Bits
 import Control.Applicative
-
+#ifndef OLD_RANDOM
+import System.Random.Stateful
+#endif
 --------------------------------------------------------------------------
 -- ** Generator type
 
@@ -92,6 +95,15 @@ instance MonadFix Gen where
       let a = unGen (f a) r n
       in a
 
+#ifndef OLD_RANDOM
+data QC = QC
+
+instance StatefulGen QC Gen where
+  uniformWord32 QC = MkGen (\r _n -> runStateGen_ r uniformWord32)
+  uniformWord64 QC = MkGen (\r _n -> runStateGen_ r uniformWord64)
+  uniformShortByteString k QC =
+    MkGen (\r _n -> runStateGen_ r (uniformShortByteString k))
+#endif
 --------------------------------------------------------------------------
 -- ** Primitive generator combinators
 


### PR DESCRIPTION
This is a preliminary PR to see if this functionality is even desired. In case that maintainers will see this as useful addition I can add some haddock and examples. Also `QC` was just the very first thing that came to mind, it can be renamed to something totally different.

This small change allows to use all of the stateful interface from new version of ` >= random-1.2.0` directly from within the `Gen` monad. For example:

* Generate anything with instance `Uniform`
```haskell
λ> import System.Random.Stateful (uniformM, uniformRM, uniformShortByteString, uniformListM)
λ> sample (uniformM QC :: Gen Int)
-6952550179692266586
-118868272850968943
...
```

* Generate anything with instance `UniformRange`
```haskell
λ> import System.Random.Stateful (uniformRM)
λ> sample (uniformRM (0, 10) QC :: Gen Double)
8.829122155155709
7.057056838467508
9.1976303653651
...
```
* Use other custom functions that generate random data:
```haskell
λ> import System.Random.Stateful (uniformListM)
λ> sample (uniformListM 5 QC :: Gen [Int])
[-332073426443689,2129047816008679820,-7574432746071061604,-7820282781062474525,2921130720166821963]
[-449122374714186863,-6428736678288918214,5352387993016661666,2292716122803412839,-7086338435263495393]
[-1122107547762043612,9027060838827498759,6642931938644004524,5993303351323562059,-274895484945480833]
....
```
* Efficient generation of binary blobs:
```haskell
λ> import System.Random.Stateful (uniformShortByteString)
λ> sample (uniformShortByteString 10 QC :: Gen ShortByteString)
"\175~\v\174\141[/\\U{"
"\STXV\NAK\FS\SOH\165^\141\163\&4"
"\245\182\183\158\152.E\232\162:"
....
λ> sample (uniformByteStringM 10 QC :: Gen ByteString)
"+\185\145\STX\202\239\ETB0\190W"
"\STX\192})\241Cr\192\194\EOT"
...
```

Of course, instead of exporting `QC` we could just create specialized functions, i.e. `uniform :: Uniform a => Gen a` etc. but that is less useful IMHO, because it would prevent usage of other general functions that people could write for `StatefulGen g m`
