### PR TITLE
Prepare for monomorphic Data.List

### DIFF
--- a/src/Test/QuickCheck/All.hs
+++ b/src/Test/QuickCheck/All.hs
@@ -29,7 +29,7 @@ import Language.Haskell.TH
 import Test.QuickCheck.Property hiding (Result)
 import Test.QuickCheck.Test
 import Data.Char
-import Data.List
+import Data.List (isPrefixOf, nubBy)
 import Control.Monad
 
 import qualified System.IO as S

--- a/src/Test/QuickCheck/Features.hs
+++ b/src/Test/QuickCheck/Features.hs
@@ -9,7 +9,7 @@ import Test.QuickCheck.State
 import Test.QuickCheck.Text
 import qualified Data.Set as Set
 import Data.Set(Set)
-import Data.List
+import Data.List (intersperse)
 import Data.IORef
 import Data.Maybe
 

--- a/src/Test/QuickCheck/Gen.hs
+++ b/src/Test/QuickCheck/Gen.hs
@@ -32,7 +32,7 @@ import Control.Applicative
   ( Applicative(..) )
 
 import Test.QuickCheck.Random
-import Data.List
+import Data.List (sortBy)
 import Data.Ord
 import Data.Maybe
 #ifndef NO_SPLITMIX

--- a/src/Test/QuickCheck/Text.hs
+++ b/src/Test/QuickCheck/Text.hs
@@ -43,7 +43,7 @@ import System.IO
   )
 
 import Data.IORef
-import Data.List
+import Data.List (intersperse, transpose)
 import Text.Printf
 import Test.QuickCheck.Exception
 

--- a/tests/Generators.hs
+++ b/tests/Generators.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE TemplateHaskell, GeneralizedNewtypeDeriving, Rank2Types, NoMonomorphismRestriction #-}
 import Test.QuickCheck
 import Test.QuickCheck.Gen.Unsafe
-import Data.List
+import Data.List (inits, sort)
 import Data.Int
 import Data.Word
 import Data.Version

--- a/tests/Split.hs
+++ b/tests/Split.hs
@@ -1,6 +1,6 @@
 import Test.QuickCheck
 import Test.QuickCheck.Random
-import Data.List
+import Data.List (group, isPrefixOf, sort)
 
 -- This type allows us to run integerVariant and get a list of bits out.
 newtype Splits = Splits { unSplits :: [Bool] } deriving (Eq, Ord, Show)


### PR DESCRIPTION
Future GHCs will monomorphise `Data.List`, returning its API to pre-FTP times and encouraging qualified import of `Data.List`, similar to other containers. See [MR 5304](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/5304) for more information. While this change has not been released yet, it already affects quality of life of folks testing GHC HEAD. The proposed patch is rather non-intrusive and backwards-compatible, so I suggest it would not hurt to merge it early.

CC @phadej 