### PR TITLE
Speed up Test.QuickCheck.Text.putTemp

### DIFF
--- a/src/Test/QuickCheck/Text.hs
+++ b/src/Test/QuickCheck/Text.hs
@@ -226,11 +226,11 @@ putPart tm@(MkTerminal res _ out _) s =
 putLine tm s = putPart tm (s ++ "\n")
 
 putTemp tm@(MkTerminal _ tmp _ err) s =
-  do n <- readIORef tmp
-     err $
-       replicate n ' ' ++ replicate n '\b' ++
-       s ++ [ '\b' | _ <- s ]
-     writeIORef tmp (length s)
+  do oldLen <- readIORef tmp
+     let newLen = length s
+         maxLen = max newLen oldLen
+     err $ s ++ replicate (maxLen - newLen) ' ' ++ replicate maxLen '\b'
+     writeIORef tmp newLen
 
 --------------------------------------------------------------------------
 -- the end.


### PR DESCRIPTION
`Test.QuickCheck.Text.putTemp` is used a tight loop, updating progress after each test iteration. For a cheap property `putTemp` itself can contribute significantly to the execution time. The new implementation emits roughly twice less characters and thus makes this overhead slightly less pronounced.

@nick8325 it would be great if this can fit into the next release.