### PR TITLE
Fix ambiguous use of `OVERLAPPING` instances in `genericShrink`

### DIFF
--- a/src/Test/QuickCheck/Arbitrary.hs
+++ b/src/Test/QuickCheck/Arbitrary.hs
@@ -409,7 +409,7 @@ instance GSubtermsIncl f a => GSubtermsIncl (M1 i c f) a where
 instance OVERLAPPING_ GSubtermsIncl (K1 i a) a where
   gSubtermsIncl (K1 x) = [x]
 
-instance OVERLAPPING_ GSubtermsIncl (K1 i a) b where
+instance GSubtermsIncl (K1 i a) b where
   gSubtermsIncl (K1 _) = []
 
 #endif


### PR DESCRIPTION
As per the following documentation for how OVERLAPPING resolves (that I'm 99% sure is the same across all GHC versions) https://downloads.haskell.org/~ghc/7.10.1/docs/html/users_guide/type-class-extensions.html#instance-overlap
the way that ghc resolves `OVERLAPPING` pragmas is that an instance that is `OVERLAPPING` will be chosen over one that isn't. It's not clear why the old code ever worked, possibly because `GSubtermsIncl (K1 i a) a` is a substitution of `GSubtermsIncl (K1 i a) b`...

Anway, with this change it's explicit that the `GSubtermsIncl (K1 i a) a` instance will be chosen over the `GSubtermsIncl (K1 i a) b` instance. 