### PR TITLE
Add additional arbitrary instances

### DIFF
--- a/src/Test/QuickCheck/Arbitrary.hs
+++ b/src/Test/QuickCheck/Arbitrary.hs
@@ -1439,7 +1439,6 @@ instance CoArbitrary a => CoArbitrary (NonEmpty a) where
 #endif
 #endif
 
-
 #ifndef NO_FIXED
 instance HasResolution a => CoArbitrary (Fixed a) where
   coarbitrary = coarbitraryReal

--- a/src/Test/QuickCheck/Arbitrary.hs
+++ b/src/Test/QuickCheck/Arbitrary.hs
@@ -1066,7 +1066,7 @@ instance Arbitrary NewlineMode where
 #if MIN_VERSION_base(4,6,0)
 instance Arbitrary1 Down where
   liftArbitrary = fmap Down
-  liftShrink shr = fmap Down . shr . getDown
+  liftShrink shr (Down a) = Down <$> shr a
 instance Arbitrary a => Arbitrary (Down a) where
   arbitrary = arbitrary1
   shrink = shrink1

--- a/src/Test/QuickCheck/Arbitrary.hs
+++ b/src/Test/QuickCheck/Arbitrary.hs
@@ -1073,6 +1073,7 @@ instance Arbitrary NewlineMode where
 instance Arbitrary1 Down where
   liftArbitrary = fmap Down
   liftShrink shr (Down a) = Down <$> shr a
+
 instance Arbitrary a => Arbitrary (Down a) where
   arbitrary = arbitrary1
   shrink = shrink1
@@ -1423,6 +1424,21 @@ instance CoArbitrary a => CoArbitrary [a] where
 
 instance (Integral a, CoArbitrary a) => CoArbitrary (Ratio a) where
   coarbitrary r = coarbitrary (numerator r,denominator r)
+
+#if defined(MIN_VERSION_base)
+#if MIN_VERSION_base(4,6,0)
+instance CoArbitrary a => CoArbitrary (Down a) where
+  coarbitrary (Down x) = coarbitrary x
+#endif
+#endif
+
+#if defined(MIN_VERSION_base)
+#if MIN_VERSION_base(4,9,0)
+instance CoArbitrary a => CoArbitrary (NonEmpty a) where
+  coarbitrary (a :| as) = coarbitrary (a, as)
+#endif
+#endif
+
 
 #ifndef NO_FIXED
 instance HasResolution a => CoArbitrary (Fixed a) where

--- a/src/Test/QuickCheck/Arbitrary.hs
+++ b/src/Test/QuickCheck/Arbitrary.hs
@@ -157,6 +157,7 @@ import Control.Monad
 
 import Data.Int(Int8, Int16, Int32, Int64)
 import Data.Word(Word, Word8, Word16, Word32, Word64)
+import Data.Ord
 import System.Exit (ExitCode(..))
 import Foreign.C.Types
 
@@ -1058,6 +1059,17 @@ instance Arbitrary NewlineMode where
   arbitrary = NewlineMode <$> arbitrary <*> arbitrary
 
   shrink (NewlineMode inNL outNL) = [NewlineMode inNL' outNL' | (inNL', outNL') <- shrink (inNL, outNL)]
+#endif
+#endif
+
+#if defined(MIN_VERSION_base)
+#if MIN_VERSION_base(4,6,0)
+instance Arbitrary1 Down where
+  liftArbitrary = fmap Down
+  liftShrink shr = fmap Down . shr . getDown
+instance Arbitrary a => Arbitrary (Down a) where
+  arbitrary = arbitrary1
+  shrink = shrink1
 #endif
 #endif
 

--- a/src/Test/QuickCheck/Arbitrary.hs
+++ b/src/Test/QuickCheck/Arbitrary.hs
@@ -150,6 +150,7 @@ import System.IO
 #if defined(MIN_VERSION_base)
 #if MIN_VERSION_base(4,9,0)
 import Data.List.NonEmpty (NonEmpty(..))
+import qualified Data.Semigroup as Semigroup
 #endif
 #endif
 
@@ -1014,6 +1015,18 @@ instance Arbitrary a => Arbitrary (Monoid.Last a) where
   shrink = map Monoid.Last . shrink . Monoid.getLast
 #endif
 
+#if defined(MIN_VERSION_base)
+#if MIN_VERSION_base(4,9,0)
+instance Arbitrary a => Arbitrary (Semigroup.Min a) where
+  arbitrary = fmap Semigroup.Min arbitrary
+  shrink = map Semigroup.Min . shrink . Semigroup.getMin
+
+instance Arbitrary a => Arbitrary (Semigroup.Max a) where
+  arbitrary = fmap Semigroup.Max arbitrary
+  shrink = map Semigroup.Max . shrink . Semigroup.getMax
+#endif
+#endif
+
 #if MIN_VERSION_base(4,8,0)
 instance Arbitrary (f a) => Arbitrary (Monoid.Alt f a) where
   arbitrary = fmap Monoid.Alt arbitrary
@@ -1583,6 +1596,15 @@ instance CoArbitrary a => CoArbitrary (Monoid.First a) where
 instance CoArbitrary a => CoArbitrary (Monoid.Last a) where
   coarbitrary = coarbitrary . Monoid.getLast
 #endif
+
+#if MIN_VERSION_base(4,9,0)
+instance CoArbitrary a => CoArbitrary (Semigroup.Min a) where
+  coarbitrary = coarbitrary . Semigroup.getMin
+
+instance CoArbitrary a => CoArbitrary (Semigroup.Max a) where
+  coarbitrary = coarbitrary . Semigroup.getMax
+#endif
+
 
 #if MIN_VERSION_base(4,8,0)
 instance CoArbitrary (f a) => CoArbitrary (Monoid.Alt f a) where

--- a/src/Test/QuickCheck/Arbitrary.hs
+++ b/src/Test/QuickCheck/Arbitrary.hs
@@ -147,6 +147,12 @@ import System.IO
 #endif
 #endif
 
+#if defined(MIN_VERSION_base)
+#if MIN_VERSION_base(4,9,0)
+import Data.List.NonEmpty (NonEmpty(..))
+#endif
+#endif
+
 import Control.Monad
   ( liftM
   , liftM2
@@ -1070,6 +1076,17 @@ instance Arbitrary1 Down where
 instance Arbitrary a => Arbitrary (Down a) where
   arbitrary = arbitrary1
   shrink = shrink1
+#endif
+#endif
+
+#if defined(MIN_VERSION_base)
+#if MIN_VERSION_base(4,9,0)
+instance Arbitrary a => Arbitrary (NonEmpty a) where
+  arbitrary = (:|) <$> arbitrary <*> arbitrary
+  shrink (a :| bs) =
+    [ a' :| bs | a' <- shrink a ] ++
+    [ b :| bs' | b : bs' <- [bs] ] ++
+    [ a :| bs' | bs' <- shrink bs ]
 #endif
 #endif
 

--- a/src/Test/QuickCheck/Function.hs
+++ b/src/Test/QuickCheck/Function.hs
@@ -105,6 +105,7 @@ import GHC.Generics hiding (C)
 #if defined(MIN_VERSION_base)
 #if MIN_VERSION_base(4,9,0)
 import Data.List.NonEmpty (NonEmpty(..))
+import qualified Data.Semigroup as Semigroup
 #endif
 #endif
 
@@ -442,11 +443,19 @@ instance Function a => Function (Monoid.Last a) where
 instance Function a => Function (Down a) where
   function = functionMap (\(Down a) -> a) Down
 #endif
-#endif
 
 #if MIN_VERSION_base(4,8,0)
 instance Function (f a) => Function (Monoid.Alt f a) where
   function = functionMap Monoid.getAlt Monoid.Alt
+#endif
+
+#if MIN_VERSION_base(4,9,0)
+instance Function a => Function (Semigroup.Min a) where
+  function = functionMap Semigroup.getMin Semigroup.Min
+
+instance Function a => Function (Semigroup.Max a) where
+  function = functionMap Semigroup.getMax Semigroup.Max
+#endif
 #endif
 
 -- poly instances

--- a/src/Test/QuickCheck/Function.hs
+++ b/src/Test/QuickCheck/Function.hs
@@ -66,6 +66,7 @@ module Test.QuickCheck.Function
 
 import Test.QuickCheck.Arbitrary
 import Test.QuickCheck.Poly
+import Test.QuickCheck.Modifiers (Small(..))
 
 import Control.Applicative
 import Data.Char
@@ -477,6 +478,11 @@ instance Function OrdB where
 
 instance Function OrdC where
   function = functionMap unOrdC OrdC
+
+-- Instances for modifiers
+
+instance Function a => Function (Small a) where
+  function = functionMap getSmall Small
 
 -- instance Arbitrary
 

--- a/src/Test/QuickCheck/Function.hs
+++ b/src/Test/QuickCheck/Function.hs
@@ -72,6 +72,7 @@ import Data.Char
 import Data.Word
 import Data.List( intersperse )
 import Data.Ratio
+import Data.Ord
 import qualified Data.IntMap as IntMap
 import qualified Data.IntSet as IntSet
 import qualified Data.Map as Map
@@ -99,6 +100,12 @@ import Data.Fixed
 
 #ifndef NO_GENERICS
 import GHC.Generics hiding (C)
+#endif
+
+#if defined(MIN_VERSION_base)
+#if MIN_VERSION_base(4,9,0)
+import Data.List.NonEmpty (NonEmpty(..))
+#endif
 #endif
 
 --------------------------------------------------------------------------
@@ -261,6 +268,13 @@ instance Function a => Function [a] where
     h (Left _)       = []
     h (Right (x,xs)) = x:xs
 
+#if defined(MIN_VERSION_base)
+#if MIN_VERSION_base(4,9,0)
+instance Function a => Function (NonEmpty a) where
+  function = functionMap (\(a :| as) -> (a, as)) (uncurry (:|))
+#endif
+#endif
+
 instance Function a => Function (Maybe a) where
   function = functionMap g h
    where
@@ -422,6 +436,13 @@ instance Function a => Function (Monoid.First a) where
 
 instance Function a => Function (Monoid.Last a) where
   function = functionMap Monoid.getLast Monoid.Last
+
+#if defined(MIN_VERSION_base)
+#if MIN_VERSION_base(4,6,0)
+instance Function a => Function (Down a) where
+  function = functionMap (\(Down a) -> a) Down
+#endif
+#endif
 
 #if MIN_VERSION_base(4,8,0)
 instance Function (f a) => Function (Monoid.Alt f a) where

--- a/src/Test/QuickCheck/Modifiers.hs
+++ b/src/Test/QuickCheck/Modifiers.hs
@@ -78,7 +78,6 @@ module Test.QuickCheck.Modifiers
 import Test.QuickCheck.Gen
 import Test.QuickCheck.Arbitrary
 import Test.QuickCheck.Exception
-import Test.QuickCheck.Function
 
 import Data.List
   ( sort
@@ -387,9 +386,6 @@ instance Integral a => Arbitrary (Small a) where
 
 instance CoArbitrary a => CoArbitrary (Small a) where
   coarbitrary (Small a) = coarbitrary a
-
-instance Function a => Function (Small a) where
-  function = functionMap getSmall Small
 
 --------------------------------------------------------------------------
 -- | @Shrink2 x@: allows 2 shrinking steps at the same time when shrinking x

--- a/src/Test/QuickCheck/Modifiers.hs
+++ b/src/Test/QuickCheck/Modifiers.hs
@@ -78,6 +78,7 @@ module Test.QuickCheck.Modifiers
 import Test.QuickCheck.Gen
 import Test.QuickCheck.Arbitrary
 import Test.QuickCheck.Exception
+import Test.QuickCheck.Function
 
 import Data.List
   ( sort
@@ -383,6 +384,12 @@ instance Functor Small where
 instance Integral a => Arbitrary (Small a) where
   arbitrary = fmap Small arbitrarySizedIntegral
   shrink (Small x) = map Small (shrinkIntegral x)
+
+instance CoArbitrary a => CoArbitrary (Small a) where
+  coarbitrary (Small a) = coarbitrary a
+
+instance Function a => Function (Small a) where
+  function = functionMap getSmall Small
 
 --------------------------------------------------------------------------
 -- | @Shrink2 x@: allows 2 shrinking steps at the same time when shrinking x


### PR DESCRIPTION
There are a bunch of types that have been added to `base` in recent years. The goal here is to bring `Test.QuickCheck.Arbitrary` up to speed with these new types.

closes #347
closes #360 