### PR TITLE
Add `withCounterexample` to get a re-useable handle on counterexamples

### DIFF
--- a/src/Test/QuickCheck.hs
+++ b/src/Test/QuickCheck.hs
@@ -78,10 +78,6 @@ module Test.QuickCheck
   , quickCheckWith
   , quickCheckWithResult
   , quickCheckResult
-#ifndef NO_TYPEABLE
-  , quickCheckWitnesses
-  , quickCheckWithWitnesses
-#endif
   , recheck
   , isSuccess
     -- ** Running tests verbosely

--- a/src/Test/QuickCheck.hs
+++ b/src/Test/QuickCheck.hs
@@ -79,8 +79,8 @@ module Test.QuickCheck
   , quickCheckWithResult
   , quickCheckResult
 #ifndef NO_TYPEABLE
-  , quickCheckWitness
-  , quickCheckWithWitness
+  , quickCheckWitnesses
+  , quickCheckWithWitnesses
 #endif
   , recheck
   , isSuccess

--- a/src/Test/QuickCheck.hs
+++ b/src/Test/QuickCheck.hs
@@ -324,7 +324,7 @@ module Test.QuickCheck
     -- ** What to do on failure
 #ifndef NO_TYPEABLE
   , Witness(..)
-  , withWitness
+  , witness
   , coerceWitness
   , castWitness
 #endif

--- a/src/Test/QuickCheck.hs
+++ b/src/Test/QuickCheck.hs
@@ -79,8 +79,8 @@ module Test.QuickCheck
   , quickCheckWithResult
   , quickCheckResult
 #ifndef NO_TYPEABLE
-  , quickCheckCounterexample
-  , quickCheckWithCounterexample
+  , quickCheckWitness
+  , quickCheckWithWitness
 #endif
   , recheck
   , isSuccess
@@ -323,10 +323,10 @@ module Test.QuickCheck
   , disjoin
     -- ** What to do on failure
 #ifndef NO_TYPEABLE
-  , Counterexample(..)
-  , withCounterexample
-  , coerceCounterexample
-  , castCounterexample
+  , Witness(..)
+  , withWitness
+  , coerceWitness
+  , castWitness
 #endif
   , counterexample
   , printTestCase

--- a/src/Test/QuickCheck.hs
+++ b/src/Test/QuickCheck.hs
@@ -78,6 +78,11 @@ module Test.QuickCheck
   , quickCheckWith
   , quickCheckWithResult
   , quickCheckResult
+#ifndef NO_TYPEABLE
+  , quickCheckCounterexample
+  , quickCheckWithCounterexample
+#endif
+  , recheck
   , isSuccess
     -- ** Running tests verbosely
   , verboseCheck
@@ -317,6 +322,12 @@ module Test.QuickCheck
   , (.||.)
   , disjoin
     -- ** What to do on failure
+#ifndef NO_TYPEABLE
+  , Counterexample(..)
+  , withCounterexample
+  , coerceCounterexample
+  , castCounterexample
+#endif
   , counterexample
   , printTestCase
   , whenFail

--- a/src/Test/QuickCheck/Property.hs
+++ b/src/Test/QuickCheck/Property.hs
@@ -532,7 +532,7 @@ withMaxSize :: Testable prop => Int -> prop -> Property
 withMaxSize n = n `seq` mapTotalResult (\res -> res{ maybeMaxTestSize = Just n })
 
 #ifndef NO_TYPEABLE
--- | Return a value in the 'counterexamples' field of the 'Result' returned by 'quickCheckResult'. Witnesses
+-- | Return a value in the 'witnesses' field of the 'Result' returned by 'quickCheckResult'. Witnesses
 -- are returned outer-most first.
 withWitness :: (Typeable a, Show a, Testable prop) => a -> prop -> Property
 withWitness a = a `seq` mapTotalResult (\res -> res{ theWitnesses = Cex a : theWitnesses res })

--- a/src/Test/QuickCheck/Property.hs
+++ b/src/Test/QuickCheck/Property.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE CPP #-}
 #ifndef NO_TYPEABLE
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE ExistentialQuantification #-}
 #endif
 #ifndef NO_SAFE_HASKELL
 {-# LANGUAGE Safe #-}
@@ -33,7 +34,7 @@ import Data.Set(Set)
 import Control.DeepSeq
 #endif
 #ifndef NO_TYPEABLE
-import Data.Typeable (Typeable)
+import Data.Typeable (Typeable, cast)
 #endif
 import Data.Maybe
 
@@ -254,6 +255,32 @@ data Callback
 data CallbackKind = Counterexample    -- ^ Affected by the 'verbose' combinator
                   | NotCounterexample -- ^ Not affected by the 'verbose' combinator
 
+#ifndef NO_TYPEABLE
+data Counterexample = forall a. (Typeable a, Show a) => Cex a
+
+instance Show Counterexample where
+  show (Cex a) = show a
+
+coerceCounterexample :: Typeable a => Counterexample -> a
+coerceCounterexample (Cex a) = case cast a of
+  Nothing -> error $ "Can't coerceCounterexample " ++ show a
+  Just a -> a
+
+castCounterexample :: Typeable a => Counterexample -> Maybe a
+castCounterexample (Cex a) = cast a
+
+data Counterexamples = NoCounterexamples
+                     | forall a. (Typeable a, Show a) => a :! Counterexamples
+
+toCounterexamples :: [Counterexample] -> Counterexamples
+toCounterexamples [] = NoCounterexamples
+toCounterexamples (Cex a : ces) = a :! toCounterexamples ces
+
+#define COUNTEREXAMPLES(a) , theCounterexamples a
+#else
+#define COUNTEREXAMPLES(a)
+#endif
+
 -- | The result of a single test.
 data Result
   = MkResult
@@ -289,6 +316,7 @@ data Result
     -- ^ the callbacks for this test case
   , testCase            :: [String]
     -- ^ the generated test case
+  COUNTEREXAMPLES(:: [Counterexample])
   }
 
 exception :: String -> AnException -> Result
@@ -329,6 +357,7 @@ succeeded, failed, rejected :: Result
       , requiredCoverage    = []
       , callbacks           = []
       , testCase            = []
+      COUNTEREXAMPLES(= [])
       }
 
 --------------------------------------------------------------------------
@@ -501,6 +530,13 @@ withMaxShrinks n = n `seq` mapTotalResult (\res -> res{ maybeMaxShrinks = Just n
 -- | Configure the maximum size a property will be tested at.
 withMaxSize :: Testable prop => Int -> prop -> Property
 withMaxSize n = n `seq` mapTotalResult (\res -> res{ maybeMaxTestSize = Just n })
+
+#ifndef NO_TYPEABLE
+-- | Return a value in the 'counterexamples' field of the 'Result' returned by 'quickCheckResult'. Counterexamples
+-- are returned outer-most first.
+withCounterexample :: (Typeable a, Show a, Testable prop) => a -> prop -> Property
+withCounterexample a = a `seq` mapTotalResult (\res -> res{ theCounterexamples = Cex a : theCounterexamples res })
+#endif
 
 -- | Check that all coverage requirements defined by 'cover' and 'coverTable'
 -- are met, using a statistically sound test, and fail if they are not met.
@@ -963,7 +999,9 @@ disjoin ps =
                      callbacks result2,
                    testCase =
                      testCase result1 ++
-                     testCase result2 }
+                     testCase result2
+                   COUNTEREXAMPLES(= theCounterexamples result1 ++ theCounterexamples result2)
+                   }
                Nothing -> result2
          -- The "obvious" semantics of .||. has:
          --   discard .||. true = true

--- a/src/Test/QuickCheck/Property.hs
+++ b/src/Test/QuickCheck/Property.hs
@@ -256,25 +256,25 @@ data CallbackKind = Counterexample    -- ^ Affected by the 'verbose' combinator
                   | NotCounterexample -- ^ Not affected by the 'verbose' combinator
 
 #ifndef NO_TYPEABLE
-data Witness = forall a. (Typeable a, Show a) => Cex a
+data Witness = forall a. (Typeable a, Show a) => Wit a
 
 instance Show Witness where
-  show (Cex a) = show a
+  show (Wit a) = show a
 
 coerceWitness :: Typeable a => Witness -> a
-coerceWitness (Cex a) = case cast a of
+coerceWitness (Wit a) = case cast a of
   Nothing -> error $ "Can't coerceWitness " ++ show a
   Just a -> a
 
 castWitness :: Typeable a => Witness -> Maybe a
-castWitness (Cex a) = cast a
+castWitness (Wit a) = cast a
 
 data Witnesses = NoWitnesses
                      | forall a. (Typeable a, Show a) => a :! Witnesses
 
 toWitnesses :: [Witness] -> Witnesses
 toWitnesses [] = NoWitnesses
-toWitnesses (Cex a : ces) = a :! toWitnesses ces
+toWitnesses (Wit a : ces) = a :! toWitnesses ces
 
 #define WITNESSES(a) , theWitnesses a
 #else
@@ -534,8 +534,8 @@ withMaxSize n = n `seq` mapTotalResult (\res -> res{ maybeMaxTestSize = Just n }
 #ifndef NO_TYPEABLE
 -- | Return a value in the 'witnesses' field of the 'Result' returned by 'quickCheckResult'. Witnesses
 -- are returned outer-most first.
-withWitness :: (Typeable a, Show a, Testable prop) => a -> prop -> Property
-withWitness a = a `seq` mapTotalResult (\res -> res{ theWitnesses = Cex a : theWitnesses res })
+witness :: (Typeable a, Show a, Testable prop) => a -> prop -> Property
+witness a = a `seq` mapTotalResult (\res -> res{ theWitnesses = Wit a : theWitnesses res })
 #endif
 
 -- | Check that all coverage requirements defined by 'cover' and 'coverTable'

--- a/src/Test/QuickCheck/Property.hs
+++ b/src/Test/QuickCheck/Property.hs
@@ -269,13 +269,6 @@ coerceWitness (Wit a) = case cast a of
 castWitness :: Typeable a => Witness -> Maybe a
 castWitness (Wit a) = cast a
 
-data Witnesses = NoWitnesses
-                     | forall a. (Typeable a, Show a) => a :! Witnesses
-
-toWitnesses :: [Witness] -> Witnesses
-toWitnesses [] = NoWitnesses
-toWitnesses (Wit a : ces) = a :! toWitnesses ces
-
 #define WITNESSES(a) , theWitnesses a
 #else
 #define WITNESSES(a)
@@ -534,6 +527,16 @@ withMaxSize n = n `seq` mapTotalResult (\res -> res{ maybeMaxTestSize = Just n }
 #ifndef NO_TYPEABLE
 -- | Return a value in the 'witnesses' field of the 'Result' returned by 'quickCheckResult'. Witnesses
 -- are returned outer-most first.
+--
+-- In ghci, for example:
+--
+-- >>> [Wit x] <- fmap witnesses . quickCheckResult $ \ x -> witness x $ x == (0 :: Int)
+-- *** Failed! Falsified (after 2 tests):
+-- 1
+-- >>> x
+-- 1
+-- >>> :t x
+-- x :: Int
 witness :: (Typeable a, Show a, Testable prop) => a -> prop -> Property
 witness a = a `seq` mapTotalResult (\res -> res{ theWitnesses = Wit a : theWitnesses res })
 #endif

--- a/src/Test/QuickCheck/Test.hs
+++ b/src/Test/QuickCheck/Test.hs
@@ -203,23 +203,6 @@ quickCheckWithResult :: Testable prop => Args -> prop -> IO Result
 quickCheckWithResult a p =
   withState a (\s -> test s (property p))
 
-#ifndef NO_TYPEABLE
--- | Test a property and get witnesses as a result. Can be used like:
---
--- @
--- $> x :! _ <- quickCheckWitnesses $ \ x -> witness (x :: Int) (x > 0)
--- *** Failed! Falsified (after 1 test):
--- 0
--- $> x
--- 0
-quickCheckWitnesses :: Testable prop => prop -> IO Witnesses
-quickCheckWitnesses = quickCheckWithWitnesses stdArgs
-
--- | Test a property, using test arguments, and get witnesses as a result.
-quickCheckWithWitnesses :: Testable prop => Args -> prop -> IO Witnesses
-quickCheckWithWitnesses args p = toWitnesses . witnesses <$> quickCheckWithResult args p
-#endif
-
 -- | Re-run a property with the seed and size that failed in a run of 'quickCheckResult'.
 recheck :: Testable prop => Result -> prop -> IO ()
 recheck res@Failure{} = quickCheckWith stdArgs{ replay = Just (usedSeed res, usedSize res)} . once

--- a/src/Test/QuickCheck/Test.hs
+++ b/src/Test/QuickCheck/Test.hs
@@ -145,8 +145,8 @@ data Result
     , failingClasses  :: Set String
       -- ^ The test case's classes (see 'classify')
 #ifndef NO_TYPEABLE
-    , counterexamples :: [Counterexample]
-      -- ^ The existentially quantified counterexamples provided by 'withCounterexample'
+    , counterexamples :: [Witness]
+      -- ^ The existentially quantified counterexamples provided by 'withWitness'
 #endif
     }
   -- | A property that should have failed did not
@@ -207,17 +207,17 @@ quickCheckWithResult a p =
 -- | Test a property and get counterexamples as a result. Can be used like:
 --
 -- @
--- $> x :! _ <- quickCheckCounterexample $ \ x -> withCounterexample (x :: Int) (x > 0)
+-- $> x :! _ <- quickCheckWitness $ \ x -> withWitness (x :: Int) (x > 0)
 -- *** Failed! Falsified (after 1 test):
 -- 0
 -- $> x
 -- 0
-quickCheckCounterexample :: Testable prop => prop -> IO Counterexamples
-quickCheckCounterexample = quickCheckWithCounterexample stdArgs
+quickCheckWitness :: Testable prop => prop -> IO Witnesses
+quickCheckWitness = quickCheckWithWitness stdArgs
 
 -- | Test a property, using test arguments, and get counterexamples as a result.
-quickCheckWithCounterexample :: Testable prop => Args -> prop -> IO Counterexamples
-quickCheckWithCounterexample args p = toCounterexamples . counterexamples <$> quickCheckWithResult args p
+quickCheckWithWitness :: Testable prop => Args -> prop -> IO Witnesses
+quickCheckWithWitness args p = toWitnesses . counterexamples <$> quickCheckWithResult args p
 #endif
 
 -- | Re-run a property with the seed and size that failed in a run of 'quickCheckResult'.
@@ -508,7 +508,7 @@ runATest st prop =
                             , failingLabels   = P.labels res
                             , failingClasses  = Set.fromList (map fst $ filter snd $ P.classes res)
 #ifndef NO_TYPEABLE
-                            , counterexamples = theCounterexamples res
+                            , counterexamples = theWitnesses res
 #endif
                             }
  where

--- a/src/Test/QuickCheck/Test.hs
+++ b/src/Test/QuickCheck/Test.hs
@@ -145,8 +145,8 @@ data Result
     , failingClasses  :: Set String
       -- ^ The test case's classes (see 'classify')
 #ifndef NO_TYPEABLE
-    , counterexamples :: [Witness]
-      -- ^ The existentially quantified counterexamples provided by 'withWitness'
+    , witnesses :: [Witness]
+      -- ^ The existentially quantified witnesses provided by 'withWitness'
 #endif
     }
   -- | A property that should have failed did not
@@ -204,20 +204,20 @@ quickCheckWithResult a p =
   withState a (\s -> test s (property p))
 
 #ifndef NO_TYPEABLE
--- | Test a property and get counterexamples as a result. Can be used like:
+-- | Test a property and get witnesses as a result. Can be used like:
 --
 -- @
--- $> x :! _ <- quickCheckWitness $ \ x -> withWitness (x :: Int) (x > 0)
+-- $> x :! _ <- quickCheckWitnesses $ \ x -> withWitness (x :: Int) (x > 0)
 -- *** Failed! Falsified (after 1 test):
 -- 0
 -- $> x
 -- 0
-quickCheckWitness :: Testable prop => prop -> IO Witnesses
-quickCheckWitness = quickCheckWithWitness stdArgs
+quickCheckWitnesses :: Testable prop => prop -> IO Witnesses
+quickCheckWitnesses = quickCheckWithWitnesses stdArgs
 
--- | Test a property, using test arguments, and get counterexamples as a result.
-quickCheckWithWitness :: Testable prop => Args -> prop -> IO Witnesses
-quickCheckWithWitness args p = toWitnesses . counterexamples <$> quickCheckWithResult args p
+-- | Test a property, using test arguments, and get witnesses as a result.
+quickCheckWithWitnesses :: Testable prop => Args -> prop -> IO Witnesses
+quickCheckWithWitnesses args p = toWitnesses . witnesses <$> quickCheckWithResult args p
 #endif
 
 -- | Re-run a property with the seed and size that failed in a run of 'quickCheckResult'.
@@ -508,7 +508,7 @@ runATest st prop =
                             , failingLabels   = P.labels res
                             , failingClasses  = Set.fromList (map fst $ filter snd $ P.classes res)
 #ifndef NO_TYPEABLE
-                            , counterexamples = theWitnesses res
+                            , witnesses = theWitnesses res
 #endif
                             }
  where

--- a/src/Test/QuickCheck/Test.hs
+++ b/src/Test/QuickCheck/Test.hs
@@ -146,7 +146,7 @@ data Result
       -- ^ The test case's classes (see 'classify')
 #ifndef NO_TYPEABLE
     , witnesses :: [Witness]
-      -- ^ The existentially quantified witnesses provided by 'withWitness'
+      -- ^ The existentially quantified witnesses provided by 'witness'
 #endif
     }
   -- | A property that should have failed did not
@@ -207,7 +207,7 @@ quickCheckWithResult a p =
 -- | Test a property and get witnesses as a result. Can be used like:
 --
 -- @
--- $> x :! _ <- quickCheckWitnesses $ \ x -> withWitness (x :: Int) (x > 0)
+-- $> x :! _ <- quickCheckWitnesses $ \ x -> witness (x :: Int) (x > 0)
 -- *** Failed! Falsified (after 1 test):
 -- 0
 -- $> x


### PR DESCRIPTION
The lack of actual values returned by `quickCheck` when a property fails has been a long standing friction. This PR introduces a simple combinator `withCounterexample :: (Typeable a, Show a, Testable prop) => a -> prop -> Property` that lets you "export" data to the `Failure` result of a property.

closes #117 
closes #310 