### PR TITLE
Make Negative's arbitrary instance work like that of Positive

### DIFF
--- a/src/Test/QuickCheck/Modifiers.hs
+++ b/src/Test/QuickCheck/Modifiers.hs
@@ -283,7 +283,7 @@ instance Functor Negative where
   fmap f (Negative x) = Negative (f x)
 
 instance (Num a, Ord a, Arbitrary a) => Arbitrary (Negative a) where
-  arbitrary = fmap Negative (arbitrary `suchThat` (< 0))
+  arbitrary = fmap Negative (fmap (negate . abs) arbitrary `suchThat` (< 0))
   shrink (Negative x) = [ Negative x' | x' <- shrink x , x' < 0 ]
 
 --------------------------------------------------------------------------


### PR DESCRIPTION
Currently `Negative` and `Positive` have `arbitrary` instances which are inconsistent with each other.

`Positive` generates an arbitrary, takes its absolute value, and checks that it is greater than 0; while `Negative` just checks the value is less than zero.

One would expect that the instance would behave like:
```haskell
arbitrary = fmap (Negative . negate . getPositive) arbitrary
```
however, because of the differences in the implementations, it does not.

This MR would make the two have consistent behavior by adjusting `Negative`'s arbitrary instance to have parity with `Positive`'s instance.

The alternative could be done, adjusting `Positive`'s instance to match that of `Negative`, but I chose to adjust it this way since the definition of arbitrary for `Positive` rejects fewer values.