### PR TITLE
For shrinks, (maxBound :: Int) is too many

### DIFF
--- a/QuickCheck.cabal
+++ b/QuickCheck.cabal
@@ -1,6 +1,6 @@
 Name: QuickCheck
 Version: 2.14.1
-Cabal-Version: >= 1.8
+Cabal-Version: >= 1.10
 Build-type: Simple
 License: BSD3
 License-file: LICENSE
@@ -70,6 +70,7 @@ flag old-random
 library
   Hs-source-dirs: src
   Build-depends: base >=4.3 && <5, containers
+  Default-language: Haskell2010
 
   -- New vs old random.
   if flag(old-random)
@@ -157,7 +158,7 @@ library
 
   -- LANGUAGE pragmas don't have any effect in Hugs.
   if impl(hugs)
-    Extensions: CPP
+    Default-Extensions: CPP
 
   if impl(uhc)
     -- Cabal under UHC needs pointing out all the dependencies of the
@@ -168,6 +169,7 @@ library
 
 Test-Suite test-quickcheck
     type: exitcode-stdio-1.0
+    Default-language: Haskell2010
     hs-source-dirs:
         examples
     main-is: Heap.hs
@@ -177,6 +179,7 @@ Test-Suite test-quickcheck
 
 Test-Suite test-quickcheck-gcoarbitrary
     type: exitcode-stdio-1.0
+    Default-language: Haskell2010
     hs-source-dirs: tests
     main-is: GCoArbitraryExample.hs
     build-depends: base, QuickCheck
@@ -187,6 +190,7 @@ Test-Suite test-quickcheck-gcoarbitrary
 
 Test-Suite test-quickcheck-generators
     type: exitcode-stdio-1.0
+    Default-language: Haskell2010
     hs-source-dirs: tests
     main-is: Generators.hs
     build-depends: base, QuickCheck
@@ -195,6 +199,7 @@ Test-Suite test-quickcheck-generators
 
 Test-Suite test-quickcheck-gshrink
     type: exitcode-stdio-1.0
+    Default-language: Haskell2010
     hs-source-dirs: tests
     main-is: GShrinkExample.hs
     build-depends: base, QuickCheck
@@ -205,6 +210,7 @@ Test-Suite test-quickcheck-gshrink
 
 Test-Suite test-quickcheck-terminal
     type: exitcode-stdio-1.0
+    Default-language: Haskell2010
     hs-source-dirs: tests
     main-is: Terminal.hs
     build-depends: base, process, deepseq >= 1.1.0.0, QuickCheck
@@ -213,6 +219,7 @@ Test-Suite test-quickcheck-terminal
 
 Test-Suite test-quickcheck-monadfix
     type: exitcode-stdio-1.0
+    Default-language: Haskell2010
     hs-source-dirs: tests
     main-is: MonadFix.hs
     build-depends: base, QuickCheck
@@ -221,12 +228,14 @@ Test-Suite test-quickcheck-monadfix
 
 Test-Suite test-quickcheck-split
     type: exitcode-stdio-1.0
+    Default-language: Haskell2010
     hs-source-dirs: tests
     main-is: Split.hs
     build-depends: base, QuickCheck
 
 Test-Suite test-quickcheck-misc
     type: exitcode-stdio-1.0
+    Default-language: Haskell2010
     hs-source-dirs: tests
     main-is: Misc.hs
     build-depends: base, QuickCheck


### PR DESCRIPTION
This PR is for master, but the patch applies for any version after 2.14.1.

I have a separate branch with the same change going back to 2.9.x

Prompted by https://recurse.social/@shapr/112141556001579384 which isn't a proper issue, but does show how this is affecting users recently.