### PR TITLE
Make Arbitrary Map instances strict

### DIFF
--- a/QuickCheck.cabal
+++ b/QuickCheck.cabal
@@ -249,6 +249,15 @@ Test-Suite test-quickcheck-split
     main-is: Split.hs
     build-depends: base, QuickCheck
 
+Test-Suite test-quickcheck-strictness
+    type: exitcode-stdio-1.0
+    Default-language: Haskell2010
+    hs-source-dirs: tests
+    main-is: Strictness.hs
+    build-depends: base, QuickCheck, containers
+    if !flag(templateHaskell) || !impl(ghc >= 7.10) || impl(haste)
+        buildable: False
+
 Test-Suite test-quickcheck-misc
     type: exitcode-stdio-1.0
     Default-language: Haskell2010

--- a/src/Test/QuickCheck/Arbitrary.hs
+++ b/src/Test/QuickCheck/Arbitrary.hs
@@ -165,9 +165,14 @@ import GHC.Generics
 #endif
 
 import qualified Data.Set as Set
-import qualified Data.Map as Map
 import qualified Data.IntSet as IntSet
+#if MIN_VERSION_containers(0,5,0)
+import qualified Data.Map.Strict as Map
+import qualified Data.IntMap.Strict as IntMap
+#else
+import qualified Data.Map as Map
 import qualified Data.IntMap as IntMap
+#endif
 import qualified Data.Sequence as Sequence
 import qualified Data.Tree as Tree
 import Data.Bits

--- a/tests/Strictness.hs
+++ b/tests/Strictness.hs
@@ -1,0 +1,42 @@
+-- Strictness tests.
+
+{-# LANGUAGE CPP, TemplateHaskell #-}
+import Test.QuickCheck
+
+import Control.Exception (Exception (..), throw)
+
+#if MIN_VERSION_containers(0,5,0)
+import Control.Exception (evaluate, try)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+#endif
+
+data Thunk
+
+instance Arbitrary Thunk where
+  arbitrary = throw ThunkError
+
+instance Show Thunk where
+  show _ = "Thunk"
+
+data ThunkError = ThunkError deriving Show
+
+instance Exception ThunkError
+
+prop_strictMap :: Property
+#if MIN_VERSION_containers(0,5,0)
+prop_strictMap = again . ioProperty $ do
+  m <- generate arbitrary
+  result <- try $ evaluate m :: IO (Either ThunkError (Map Int Thunk))
+  pure $ case result of
+    Right _ | not (Map.null m) -> counterexample ("Thunks in Map: " ++ show m) False
+    _ -> property True
+#else
+prop_strictMap = once $ property True
+#endif
+
+return []
+main :: IO ()
+main = do
+  True <- $quickCheckAll
+  return ()


### PR DESCRIPTION
Strict and lazy Maps share the same type so it's not possible to have separate instances for them. The existing instance uses the lazy interface and thus produces a map containing lazy values even when the client is using the strict interface. This is a violation of the invariant of a strict Map, whereas there's no invariant to be violated with a lazy Map. It seems better, therefore, to make the instance default to producing strict values.

Note that strict maps evaluate their values only to WHNF, so a `Map Int (Maybe Char)` would still contain thunks.

If introducing a dependency on `nothunks` (even if only for testing) might be a problem, the commit containing the test can just be dropped. I added it mainly as a way of proving to myself that the fix works. (The test fails without the commit containing the fix.)

I also didn't add any conditional compilation for non-GHC builds, which I assume runs against the traditional philosophy of QuickCheck. If you want to preserve this, that would be another reason to drop the testing commit.