### PR TITLE
Fix strictness of classify

### DIFF
--- a/src/Test/QuickCheck/Property.hs
+++ b/src/Test/QuickCheck/Property.hs
@@ -1,7 +1,6 @@
 {-# OPTIONS_HADDOCK hide #-}
 -- | Combinators for constructing properties.
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE BangPatterns #-}
 #ifndef NO_TYPEABLE
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE ExistentialQuantification #-}
@@ -656,10 +655,11 @@ classify :: Testable prop =>
             Bool    -- ^ @True@ if the test case should be labelled.
          -> String  -- ^ Label.
          -> prop -> Property
-classify !b s =
+classify b s =
 #ifndef NO_DEEPSEQ
   s `deepseq`
 #endif
+  b `seq`
   mapTotalResult $
     \res -> res { classes = (s, b):classes res }
 

--- a/src/Test/QuickCheck/Property.hs
+++ b/src/Test/QuickCheck/Property.hs
@@ -1,6 +1,7 @@
 {-# OPTIONS_HADDOCK hide #-}
 -- | Combinators for constructing properties.
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE BangPatterns #-}
 #ifndef NO_TYPEABLE
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE ExistentialQuantification #-}
@@ -655,7 +656,7 @@ classify :: Testable prop =>
             Bool    -- ^ @True@ if the test case should be labelled.
          -> String  -- ^ Label.
          -> prop -> Property
-classify b s =
+classify !b s =
 #ifndef NO_DEEPSEQ
   s `deepseq`
 #endif

--- a/tests/DiscardRatio.hs
+++ b/tests/DiscardRatio.hs
@@ -53,4 +53,4 @@ main = do
   -- Annoying interactions of discard and cover
   quickCheckYes $ forAllBlind (oneof [return True, return discard]) $ \ b -> cover 10 b "b" True
   quickCheck $ cover 10 discard "b" True
-  quickCheck $ classify "b" discard True
+  quickCheck $ classify discard "b" True

--- a/tests/DiscardRatio.hs
+++ b/tests/DiscardRatio.hs
@@ -49,3 +49,8 @@ main = do
   putStrLn "\nExpecting success (discard ratio 40): x < 50 ==> True"
   quickCheckYes $ withDiscardRatio 40 p50
   quickCheckYesWith stdArgs{maxDiscardRatio = 40} p50
+
+  -- Annoying interactions of discard and cover
+  quickCheckYes $ forAllBlind (oneof [pure True, pure discard]) $ \ b -> cover 10 b "b" True
+  quickCheck $ cover 10 discard "b" True
+  quickCheck $ classify "b" discard True

--- a/tests/DiscardRatio.hs
+++ b/tests/DiscardRatio.hs
@@ -51,6 +51,6 @@ main = do
   quickCheckYesWith stdArgs{maxDiscardRatio = 40} p50
 
   -- Annoying interactions of discard and cover
-  quickCheckYes $ forAllBlind (oneof [pure True, pure discard]) $ \ b -> cover 10 b "b" True
+  quickCheckYes $ forAllBlind (oneof [return True, return discard]) $ \ b -> cover 10 b "b" True
   quickCheck $ cover 10 discard "b" True
   quickCheck $ classify "b" discard True


### PR DESCRIPTION
I made a dumb-dumb in a previous PR that changed the strictness of `classify`, which resulted in poor interaction with `discard`. This fixes that.

closes #406 