### PR TITLE
add withProgress to make testing frameworks get out of the internals

### DIFF
--- a/QuickCheck.cabal
+++ b/QuickCheck.cabal
@@ -287,3 +287,10 @@ Test-Suite test-quickcheck-monoids
       cpp-options: -DNO_SEMIGROUP_SUPERCLASS
     if !impl(ghc >= 8.0)
       cpp-options: -DNO_SEMIGROUP_CLASS
+
+Test-Suite test-quickcheck-withprogress
+    type: exitcode-stdio-1.0
+    Default-language: Haskell2010
+    hs-source-dirs: tests
+    main-is: WithProgress.hs
+    build-depends: base, QuickCheck

--- a/src/Test/QuickCheck.hs
+++ b/src/Test/QuickCheck.hs
@@ -73,7 +73,7 @@ module Test.QuickCheck
   (
     -- * Running tests
     quickCheck
-  , Args(..), Result(..)
+  , Args(..), Result(..), TestProgress(..)
   , stdArgs
   , quickCheckWith
   , quickCheckWithResult
@@ -328,6 +328,7 @@ module Test.QuickCheck
 #endif
   , counterexample
   , printTestCase
+  , withProgress
   , whenFail
   , whenFail'
   , expectFailure

--- a/src/Test/QuickCheck/Property.hs
+++ b/src/Test/QuickCheck/Property.hs
@@ -453,16 +453,20 @@ whenFail' m =
 -- | Performs an IO action every time a property is tested, after every test.
 -- The IO action is allowed to depend on @TestProgress@, which contains information
 -- regarding how testing is progressing.
+--
+-- Note: QC invokes callbacks before the internal state has been updated to reflect the
+-- most recent test. The means that e.g. @currentPassed@ will, after the first test has
+-- been executed, still show 0.
 withProgress :: Testable prop => (TestProgress -> IO ()) -> prop -> Property
 withProgress m =
   callback $ PostTest NotCounterexample $ \st _r ->
-    let tp = TestProgress { numpassed    = numSuccessTests st
-                          , numdiscarded = numDiscardedTests st
-                          , maxtests     = maxSuccessTests st
+    let tp = TestProgress { currentPassed    = numSuccessTests st
+                          , currentDiscarded = numDiscardedTests st
+                          , maxTests         = maxSuccessTests st
                           
-                          , numshrinks       = numSuccessShrinks st
-                          , numfailedshrinks = numTryShrinks st
-                          , numtotalshrinks  = numTotTryShrinks st
+                          , currentShrinks       = numSuccessShrinks st
+                          , currentFailedShrinks = numTryShrinks st
+                          , currentTotalShrinks  = numTotTryShrinks st
                           }
     in m tp
 

--- a/src/Test/QuickCheck/Property.hs
+++ b/src/Test/QuickCheck/Property.hs
@@ -460,10 +460,9 @@ whenFail' m =
 withProgress :: Testable prop => (TestProgress -> IO ()) -> prop -> Property
 withProgress m =
   callback $ PostTest NotCounterexample $ \st _r ->
-    let tp = TestProgress { currentPassed    = numSuccessTests st
-                          , currentDiscarded = numDiscardedTests st
-                          , maxTests         = maxSuccessTests st
-                          
+    let tp = TestProgress { currentPassed        = numSuccessTests st
+                          , currentDiscarded     = numDiscardedTests st
+                          , maxTests             = maxSuccessTests st
                           , currentShrinks       = numSuccessShrinks st
                           , currentFailedShrinks = numTryShrinks st
                           , currentTotalShrinks  = numTotTryShrinks st

--- a/src/Test/QuickCheck/State.hs
+++ b/src/Test/QuickCheck/State.hs
@@ -103,7 +103,6 @@ data TestProgress
     currentPassed        :: Int -- ^ Number of tests passed so far
   , currentDiscarded     :: Int -- ^ Number of discared tests so far
   , maxTests             :: Int -- ^ Number of tests to execute
-
   , currentShrinks       :: Int -- ^ Number of successful shrinking steps
   , currentFailedShrinks :: Int -- ^ Number of failed shrinking steps since last successful one
   , currentTotalShrinks  :: Int -- ^ Total number of failed shrinking steps

--- a/src/Test/QuickCheck/State.hs
+++ b/src/Test/QuickCheck/State.hs
@@ -94,5 +94,20 @@ data Confidence =
     }
   deriving Show
 
+-- | TestProgress, contains information that might be interesting to external
+-- libraries, e.g. Tasty. From this it is possible to install your own callbacks
+-- that reports e.g. progress.
+data TestProgress
+  = TestProgress
+  {
+    numpassed        :: Int -- ^ Number of tests passed so far
+  , numdiscarded     :: Int -- ^ Number of discared tests so far
+  , maxtests         :: Int -- ^ Number of tests to execute
+
+  , numshrinks       :: Int -- ^ Number of successful shrinking steps
+  , numfailedshrinks :: Int -- ^ Number of failed shrinking steps since last successful one
+  , numtotalshrinks  :: Int -- ^ total number of failed shrinking steps
+  }
+
 --------------------------------------------------------------------------
 -- the end.

--- a/src/Test/QuickCheck/State.hs
+++ b/src/Test/QuickCheck/State.hs
@@ -100,14 +100,14 @@ data Confidence =
 data TestProgress
   = TestProgress
   {
-    numpassed        :: Int -- ^ Number of tests passed so far
-  , numdiscarded     :: Int -- ^ Number of discared tests so far
-  , maxtests         :: Int -- ^ Number of tests to execute
+    currentPassed        :: Int -- ^ Number of tests passed so far
+  , currentDiscarded     :: Int -- ^ Number of discared tests so far
+  , maxTests             :: Int -- ^ Number of tests to execute
 
-  , numshrinks       :: Int -- ^ Number of successful shrinking steps
-  , numfailedshrinks :: Int -- ^ Number of failed shrinking steps since last successful one
-  , numtotalshrinks  :: Int -- ^ total number of failed shrinking steps
-  }
+  , currentShrinks       :: Int -- ^ Number of successful shrinking steps
+  , currentFailedShrinks :: Int -- ^ Number of failed shrinking steps since last successful one
+  , currentTotalShrinks  :: Int -- ^ Total number of failed shrinking steps
+  } deriving Show
 
 --------------------------------------------------------------------------
 -- the end.

--- a/src/Test/QuickCheck/State.hs
+++ b/src/Test/QuickCheck/State.hs
@@ -99,8 +99,7 @@ data Confidence =
 -- that reports e.g. progress.
 data TestProgress
   = TestProgress
-  {
-    currentPassed        :: Int -- ^ Number of tests passed so far
+  { currentPassed        :: Int -- ^ Number of tests passed so far
   , currentDiscarded     :: Int -- ^ Number of discared tests so far
   , maxTests             :: Int -- ^ Number of tests to execute
   , currentShrinks       :: Int -- ^ Number of successful shrinking steps

--- a/tests/WithProgress.hs
+++ b/tests/WithProgress.hs
@@ -1,10 +1,68 @@
 import Test.QuickCheck
 import Test.QuickCheck.Monadic
 
-main = quickCheck prop_test_withProgress
+import Data.IORef
+import System.Exit (exitSuccess, exitFailure)
+import Control.Monad (when)
 
-prop_test_withProgress :: Property
-prop_test_withProgress =
+main :: IO ()
+main = do
+  succ <- newIORef 0
+  disc <- newIORef 0
+
+  -- test 1  
+  quickCheck (propTestWithProgress succ)
+  i <- readIORef succ
+  when (i /= 99) exitFailure
+
+  modifyIORef succ (const 0)
+
+  -- test 2
+  quickCheck (proptestWithProgressDiscard succ disc)
+  i1 <- readIORef succ
+  i2 <- readIORef disc
+  putStrLn $ show i1
+  putStrLn $ show i2
+  when (i1 /= 0 || i2 /= 999) exitFailure
+
+  modifyIORef succ (const 0)
+  modifyIORef disc (const 0)
+
+  -- test 3
+  quickCheck (proptestWithProgressNotInstalled succ disc)
+  i1 <- readIORef succ
+  i2 <- readIORef disc
+  putStrLn $ show i1
+  putStrLn $ show i2
+  when (i1 /= 0 || i2 /= 0) exitFailure
+
+  exitSuccess
+
+-- all these tests succeed, incrementing the counter every time
+propTestWithProgress :: IORef Int -> Property
+propTestWithProgress ref =
     forAll (arbitrary :: Gen Int) $ \n ->
-        withProgress (\p -> putStrLn $ "executed tests: " ++ show (numpassed p))
-      $ n == n
+        withProgress (\p -> modifyIORef ref (\_ -> currentPassed p))
+        $ n == n
+
+-- all of these tests are discarded, never updating the currentPassed counter, but always
+-- the currentDiscarded one.
+proptestWithProgressDiscard :: IORef Int -> IORef Int -> Property
+proptestWithProgressDiscard succ disc =
+    forAll (arbitrary :: Gen Int) $ \n ->
+        withProgress (\p -> do
+          modifyIORef succ (\_ -> currentPassed p)
+          modifyIORef disc (\_ -> currentDiscarded p))
+        $ n > 1000 ==>
+          n == n
+
+-- The callback is installed after the test on n, meaning that since all tests are
+-- discarded, it will never be called. It will never be executed.
+proptestWithProgressNotInstalled :: IORef Int -> IORef Int -> Property
+proptestWithProgressNotInstalled succ disc =
+    forAll (arbitrary :: Gen Int) $ \n ->
+      n > 1000 ==>
+        withProgress (\p -> do
+          modifyIORef succ (\_ -> currentPassed p)
+          modifyIORef disc (\_ -> currentDiscarded p))
+        $ n == n

--- a/tests/WithProgress.hs
+++ b/tests/WithProgress.hs
@@ -1,0 +1,10 @@
+import Test.QuickCheck
+import Test.QuickCheck.Monadic
+
+main = quickCheck prop_test_withProgress
+
+prop_test_withProgress :: Property
+prop_test_withProgress =
+    forAll (arbitrary :: Gen Int) $ \n ->
+        withProgress (\p -> putStrLn $ "executed tests: " ++ show (numpassed p))
+      $ n == n


### PR DESCRIPTION
In an effort to chuck some of the testing frameworks (Tasty, Hspec) out of the internals, I add `withProgress`. Their usage of the internals seemed to be quite innocent (primarily inspecting the testing state to report the current progress by themselves). Here's a combinator that gives an alternative way of doing this.

E.g. Tasty currently does this
```Haskell
import qualified Test.QuickCheck as QC
import qualified Test.QuickCheck.Property as QCP
import qualified Test.QuickCheck.State as QC

quickCheck :: (Progress -> IO ())
           -> QC.Args
           -> QC.Property
           -> IO QC.Result
quickCheck yieldProgress args
  = (.) (QC.quickCheckWithResult args)
  $ QCP.callback
  $ QCP.PostTest QCP.NotCounterexample
  $ \st@QC.MkState {QC.maxSuccessTests, QC.numSuccessTests} _ ->
    yieldProgress $
      if QC.numTotTryShrinks st > 0 then
        emptyProgress {
            progressText = showShrinkCount st
          }
      else
        emptyProgress {
            progressPercent = fromIntegral numSuccessTests / fromIntegral maxSuccessTests
          }
```

and now it is enough to do

```Haskell
import qualified Test.QuickCheck as QC

quickCheck :: (Progress -> IO ())
           -> QC.Args
           -> QC.Property
           -> IO QC.Result
quickCheck yieldProgress args =
  (.) (QC.quickCheckWithResult args)
  $ QC.withProgress $ \p ->
      yieldProgress $
        if QC.numtotalshrinks p > 0 then
          emptyProgress {
              progressText = showShrinkCount p
            }
        else
          emptyProgress {
              progressPercent = fromIntegral (QC.numpassed p) / fromIntegral (QC.maxtests p)
            }
```

Here's the [Hspec](https://github.com/hspec/hspec/commit/ac5b934db4af9b62c48bf3c6a81ec5751188672d) version using this combinator.
Here's the [Tasty](https://github.com/UnkindPartition/tasty/commit/0f52efbd26427b54053119c5acd3ffd6a73f0ce6) version using this combinator.

It makes sense to sit down and figure out a good API for frameworks for interacting with QC, but it takes a while. This is a quick approach to separating testing frameworks from internals. There were some other usages of internals that will need similar treatment (e.g. a framework is importing `Test.QuickCheck.Random` to do something innocent, so there should be a similarly simple fix there).

I may make further PRs in the same spirit as this one. This is in preparation for proposing big changes to the testing loop.