### PR TITLE
Remove duplicate Nil from docs on shrinking of trees

### DIFF
--- a/src/Test/QuickCheck/Arbitrary.hs
+++ b/src/Test/QuickCheck/Arbitrary.hs
@@ -286,8 +286,8 @@ class Arbitrary a where
   -- > shrink (Branch x l r) =
   -- >   -- shrink Branch to Nil
   -- >   [Nil] ++
-  -- >   -- shrink to subterms
-  -- >   [l, r] ++
+  -- >   -- shrink to non-Nil subterms
+  -- >   [t | t@Branch{} <- [l, r]] ++
   -- >   -- recursively shrink subterms
   -- >   [Branch x' l' r' | (x', l', r') <- shrink (x, l, r)]
   --


### PR DESCRIPTION
No need to shrink to `Nil` multiple times.

Details and beyond can be found in my [post](https://github.com/effectfully-ou/sketches/tree/5e2826ec122598e8518e28cfcee62c38ee6da6c9/better-counterexample-minimization) on shrinking trees.