### PR TITLE
Use "nightly" binaries for MicroHs CI

### DIFF
--- a/.github/workflows/microhs-ci.yml
+++ b/.github/workflows/microhs-ci.yml
@@ -8,13 +8,12 @@ on:
       - 'master'
   schedule:
     - cron: 0 0 * * *
-
 jobs:
   linux:
     name: MicroHs-CI - Linux
     runs-on: ubuntu-24.04
     steps:
-    - uses: sol/setup-MicroHs@add-setup-action
+    - uses: sol/setup-MicroHs@nightly
     - name: checkout QuickCheck repo
       uses: actions/checkout@v4
     - name: build QuickCheck


### PR DESCRIPTION
This reduces the build time ~by 2 minutes~ from over 5m down to 1m 26s.

~Please wait with merging this until the related changes are upstream.~