### PR TITLE
Update microhs-ci.yml

### DIFF
--- a/.github/workflows/microhs-ci.yml
+++ b/.github/workflows/microhs-ci.yml
@@ -16,5 +16,6 @@ jobs:
     - uses: sol/setup-MicroHs@nightly
     - name: checkout QuickCheck repo
       uses: actions/checkout@v4
+    - run: find ~/.mcabal/ -name "QuickCheck-*.pkg" -delete
     - name: test QuickCheck
       run: ./test-mhs


### PR DESCRIPTION
@MaximilianAlgehed something like this might be needed, otherwise CI will fail on version bumps, as without this change you will end up with two versions of QuickCheck[^1] and `mcabal` can't deal with multiple versions of the same package.

As I said, this is only a problem once you bump the version.  You may choose to leave this PR open until you run into the issue and at that point double check that this PR actually solves the issue.

[^1]: one version from the cache and one version from `mcabal install`; without a version bump `mcabal install` will simply overwrite the existing version