### PR TITLE
Dont use compat pacakges

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -71,7 +71,7 @@ jobs:
           ghc-version: ${{matrix.ghc-version}}
           enable-stack: true
       - run: |
-          printf "snapshot: ${{ matrix.resolver }}\npackages: [.]\nextra-deps: [data-array-byte-0.1.0.1]\nsystem-ghc: true" > stack.yaml
+          printf "snapshot: ${{ matrix.resolver }}\npackages: [.]\nsystem-ghc: true" > stack.yaml
           cat stack.yaml
       - uses: actions/cache@v4
         with:

--- a/QuickCheck.cabal
+++ b/QuickCheck.cabal
@@ -144,9 +144,6 @@ library
   if impl(ghc >= 9.8)
     ghc-options: -Wno-x-partial
 
-  if impl(ghc < 9.4)
-    Build-depends: data-array-byte
-
   -- Switch off most optional features on non-GHC systems.
   if !impl(ghc) && !impl(mhs)
     -- If your Haskell compiler can cope without some of these, please

--- a/src/Test/QuickCheck/Arbitrary.hs
+++ b/src/Test/QuickCheck/Arbitrary.hs
@@ -208,8 +208,10 @@ import System.Console.GetOpt
 
 import Data.Functor.Contravariant
 
+#if MIN_VERSION_base(4,17,0)
 import Data.Array.Byte
 import qualified GHC.Exts as Exts
+#endif
 
 #if MIN_VERSION_base(4,16,0)
 import Data.Tuple
@@ -1140,6 +1142,7 @@ instance CoArbitrary a => CoArbitrary (Xor a) where
 #endif
 
 #if !defined(__MHS__)
+#if MIN_VERSION_base(4, 17, 0)
 instance Arbitrary ByteArray where
 #if MIN_VERSION_random(1,3,0)
   arbitrary = do
@@ -1153,6 +1156,7 @@ instance Arbitrary ByteArray where
 
 instance CoArbitrary ByteArray where
   coarbitrary = coarbitrary . Exts.toList
+#endif
 
 -- MicroHs does not have Exts.fromList
 #endif /* !defined(__MHS__) */

--- a/src/Test/QuickCheck/Function.hs
+++ b/src/Test/QuickCheck/Function.hs
@@ -95,8 +95,10 @@ import Text.Printf
 import System.IO
 import System.Exit
 import Data.Version
+#if MIN_VERSION_base(4, 17, 0)
 import Data.Array.Byte
 import qualified GHC.Exts as Exts
+#endif
 
 #if defined(__MHS__)
 import Data.ZipList
@@ -546,8 +548,10 @@ instance Function Version where
           from (a, b) = Version a b
 
 #if !defined(__MHS__)
+#if MIN_VERSION_base(4, 17, 0)
 instance Function ByteArray where
   function = functionMap Exts.toList Exts.fromList
+#endif
 #endif
 
 #if MIN_VERSION_base(4,16,0)


### PR DESCRIPTION
closes #448

The reason for this rationale is that deciding to support some compat packages results in having to support all compat packages. This immediately opens the door to having to decide which compat package to use, taking side in the inevitable (future) flame war, etc. etc.