### PR TITLE
Fix bug in heap example and silently failing tests

### DIFF
--- a/examples/Heap.hs
+++ b/examples/Heap.hs
@@ -144,7 +144,7 @@ instance (Ord a, Arbitrary a) => Arbitrary (Heap a) where
 -- main
 
 return []
-main = $quickCheckAll
+main = do True <- $quickCheckAll; return ()
 
 --------------------------------------------------------------------------
 -- the end.

--- a/examples/Heap_Program.hs
+++ b/examples/Heap_Program.hs
@@ -187,7 +187,7 @@ prop_ToSortedList (HeapPP _ h) =
 -- main
 
 return []
-main = $(quickCheckAll)
+main = do True <- $quickCheckAll; return ()
 
 --------------------------------------------------------------------------
 -- the end.

--- a/examples/Heap_ProgramAlgebraic.hs
+++ b/examples/Heap_ProgramAlgebraic.hs
@@ -245,7 +245,7 @@ prop_ToSortedList (HeapPP _ (h :: Heap OrdA)) =
 -- main
 
 return []
-main = $(quickCheckAll)
+main = do True <- $quickCheckAll; return ()
 
 --------------------------------------------------------------------------
 -- the end.

--- a/examples/Merge.hs
+++ b/examples/Merge.hs
@@ -110,7 +110,7 @@ prop_Merging (xss :: [OrderedList Int]) =
 --  mapSize (`div` 2) $ \(xss :: [OrderedList Int]) ->
 
 return []
-main = $quickCheckAll
+main = do True <- $quickCheckAll; return ()
 
 --------------------------------------------------------------------------
 -- the end.

--- a/examples/Set.hs
+++ b/examples/Set.hs
@@ -201,7 +201,7 @@ prop_FromList' (xs :: [Int]) =
 -- main
 
 return []
-main = $quickCheckAll
+main = do True <- $quickCheckAll; return ()
 
 --------------------------------------------------------------------------
 -- the end.

--- a/examples/Simple.hs
+++ b/examples/Simple.hs
@@ -40,7 +40,7 @@ prop_conj = counterexample "Simon Thompson" $(monomorphic 'prop_SimonThompson) .
 prop_disj = counterexample "reverse" $(monomorphic 'prop_Reverse) .||.
             counterexample "Simon Thompson" $(monomorphic 'prop_SimonThompson)
 return []
-main = $quickCheckAll
+main = do True <- $quickCheckAll; return ()
 
 --------------------------------------------------------------------------
 -- the end.

--- a/tests/Monoids.hs
+++ b/tests/Monoids.hs
@@ -142,5 +142,5 @@ prop_some_mconcat_law :: Blind Some -> Blind Some -> Property
 prop_some_mconcat_law = check_mconcat_law
 
 return []
-main = $quickCheckAll
+main = do True <- $quickCheckAll; return ()
 


### PR DESCRIPTION
Fixes #465

`$quickCheckAll` has type `IO Bool`, which is allowed as the type of `main`, but a `False` result will not translate to a non-zero exit code. Thus, to use it in a test suite you need something like this
```haskell
main = do True <- $quickCheckAll; return ()
```