### PR TITLE
Simplify `shrinkIntegral` (no behaviour change)

### DIFF
--- a/src/Test/QuickCheck/Arbitrary.hs
+++ b/src/Test/QuickCheck/Arbitrary.hs
@@ -1482,20 +1482,8 @@ shrinkMapBy f g shr = map f . shr . g
 -- | Shrink an integral number.
 shrinkIntegral :: Integral a => a -> [a]
 shrinkIntegral x =
-  nub $
-  [ -x
-  | x < 0, -x > x
-  ] ++
-  [ x'
-  | x' <- takeWhile (<< x) (0:[ x - i | i <- tail (iterate (`quot` 2) x) ])
-  ]
- where
-   -- a << b is "morally" abs a < abs b, but taking care of overflow.
-   a << b = case (a >= 0, b >= 0) of
-            (True,  True)  -> a < b
-            (False, False) -> a > b
-            (True,  False) -> a + b < 0
-            (False, True)  -> a + b > 0
+  [ -x | x < 0, -x > x ] ++
+  [ x - i | i <- takeWhile (/= 0) (iterate (`quot` 2) x)]
 
 -- | Shrink an element of a bounded enumeration.
 --


### PR DESCRIPTION
Hi, I was browsing the implementation of `shrinkIntegral` and would like to suggest some simplifications; the details are described in the commit message (quoted below). I also have a couple of ideas for improvement that involve behaviour changes, listed at the very end of this message.

> This commit simplifies `shrinkIntegral` without changing its behaviour (test included below). The simplifications are as follows:
> 
> * `nub` is unnecessary because the values are guaranteed to be unique.
> 
> * The complicated logic for checking `abs a < abs b` while taking care of overflow can be eliminated by checking for `i /= 0` rather than `abs (x - i) < abs x`.
> 
> * However, we need to be careful because we need to exclude `0` in the case `x = 0` (as done by the original code). This can be done by handling `0` as part of the general case (by removing `0:` and removing `tail`).
> 
> The following program checks that the new implementation produces the same values as the original implementation on a range of Int32 values (centred around 0 and around maxBound/minBound).
> 
> ```
> import Test.QuickCheck (shrinkIntegral)
> import Data.Int (Int32)
> 
> main = do
>   let values :: [Int32] = [centre + delta | centre <- [0, maxBound], delta <- [-1000..1000]]
>   let failures = [v | v <- values, shrinkIntegral' v /= shrinkIntegral v]
>   putStrLn $ "failures: " ++ show failures
> 
> shrinkIntegral' x =
>   [ -x | x < 0, -x > x ] ++
>   [ x - i | i <- takeWhile (/= 0) (iterate (`quot` 2) x)]
> ```

Here are my ideas for improvement that involve behaviour changes, would you be interested in PRs for them?

* The current implementation (and the simplified version in this PR) includes 0 as a candidate in all cases (except when `x` is 0 to avoid an infinite loop). I propose only including 0 as a candidate when x is ±1, because I think in general 0 is unlikely to be a successful candidate, so trying it after each shrink is wasteful. (With this proposed change, 0 will still be considered after log(n) shrink steps.)

* I also propose changing the order of the candidates for negative values: I think `abs x` should be tried last rather than first, because for propositions that only fail on negative integers, it is wasteful to try `abs x` after each shrink operation. I am not sure if this is more logical or less logical for users than the current approach -- it could be argued that it is more logical to first try `abs x` so that shrinking can proceed on positive integers (as done currently), but it could also be argued that shrinking should preserve the sign and only try `abs x` as a last resort (as in my proposed change).

* I came up with a (somewhat complicated) integer shrinking scheme that reduces the number of candidates at each step from log(n) to 2, while still only requiring O(log(n)) shrink operations to find the minimal counterexample. Would you be interested in this scheme?  
  (The advantage of reducing the number of candidates is that it reduces the total number of checks needed to shrink composite types that contain many integers, since shrinkers for composite structures such as lists retry all candidates for all subobjects after each shrink step; ideally, they would retry the most-recently-shrunk subobject before retrying earlier subobjects, but that doesn't seem possible without side effects; the next best solution is to reduce the number of candidates as much as possible.)