### PR TITLE
Fix typos

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -48,7 +48,7 @@ assertDeepExceptionIO (thanks to Alexey Kuleshevich)
 * Fix withMaxSuccess not working when checkCoverage is turned on
 * Fix a bug whereby an unfortunately timed discard could unduly fail a
 property running with checkCoverage
-* Fix Arbitrary intance for Map breaking invariants from
+* Fix Arbitrary instance for Map breaking invariants from
 Data.Map.Strict (thanks to Neil Mayhew)
 * Fix non-covered classes not showing up in output as 0% covered
 * Fix Negative's Arbitrary instance discarding an unnecessary number

--- a/src/Test/QuickCheck/State.hs
+++ b/src/Test/QuickCheck/State.hs
@@ -100,7 +100,7 @@ data Confidence =
 data TestProgress
   = TestProgress
   { currentPassed        :: Int -- ^ Number of tests passed so far
-  , currentDiscarded     :: Int -- ^ Number of discared tests so far
+  , currentDiscarded     :: Int -- ^ Number of discarded tests so far
   , maxTests             :: Int -- ^ Number of tests to execute
   , currentShrinks       :: Int -- ^ Number of successful shrinking steps
   , currentFailedShrinks :: Int -- ^ Number of failed shrinking steps since last successful one

--- a/src/Test/QuickCheck/Test.hs
+++ b/src/Test/QuickCheck/Test.hs
@@ -585,7 +585,7 @@ showTable k mtable m =
   (map format .
    -- Descending order of occurrences
    reverse . sortBy (comparing snd) .
-   -- If #occurences the same, sort in increasing order of key
+   -- If #occurrences the same, sort in increasing order of key
    -- (note: works because sortBy is stable)
    reverse . sortBy (comparing fst) $ Map.toList m)
   where

--- a/tests/Generators.hs
+++ b/tests/Generators.hs
@@ -206,7 +206,7 @@ prop_B1 (B1 n) = expectFailure $ n === n + 1
 
 -- Double properties:
 
--- We occasionaly generate duplicates.
+-- We occasionally generate duplicates.
 prop_double_duplicate_list :: [Double] -> Property
 prop_double_duplicate_list xs = expectFailure $ nub xs === xs where
   sorted = sort xs


### PR DESCRIPTION
Found via `codespell -L mapp,typ,vart,tupe,numer,caf,nd,wit,typess`